### PR TITLE
Fixing icache bug where for each miss we also count a hit.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@ Version 3.2.3+edits (development branch) versus 3.2.3
   
 - Bug fixes:
     - Fixed bug #81, fix ordering of pushing branch entries to the stack
+    - Fixed a bug where for each icache miss we also count a hit
 
 Version 3.2.3 versus 3.2.2
 - Bug fixes:

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -82,6 +82,7 @@ public:
    bool is_write() {return m_access.is_write();}
    void set_addr(new_addr_type addr) { m_access.set_addr(addr); }
    new_addr_type get_addr() const { return m_access.get_addr(); }
+   unsigned get_access_size() const { return m_access.get_size(); }
    new_addr_type get_partition_addr() const { return m_partition_addr; }
    unsigned get_sub_partition_id() const { return m_raw_addr.sub_partition; }
    bool     get_is_write() const { return m_access.is_write(); }

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -601,6 +601,7 @@ void shader_core_ctx::fetch()
             mem_fetch *mf = m_L1I->next_access();
             m_warp[mf->get_wid()].clear_imiss_pending();
             m_inst_fetch_buffer = ifetch_buffer_t(m_warp[mf->get_wid()].get_pc(), mf->get_access_size(), mf->get_wid());
+            assert( m_warp[mf->get_wid()].get_pc() == (mf->get_addr()-PROGRAM_MEM_START)); // Verify that we got the instruction we were expecting.
             m_inst_fetch_buffer.m_valid = true;
             m_warp[mf->get_wid()].set_last_fetch(gpu_sim_cycle);
             delete mf;


### PR DESCRIPTION
Making sure we immediately fetch after a MISS comes back from cache. This prevents counting a hit the next time we try to fetch the same instruction.