### PR TITLE
Fixed bug #88. Initial ejection buffer and boundary buffer with the interconnection node number

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 3.2.3+edits (development branch) versus 3.2.3
 - Bug fixes:
     - Fixed bug #81, fix ordering of pushing branch entries to the stack
     - Fixed a bug where for each icache miss we also count a hit
+    - Fixed bug #88, Ejection buffer and Boundary buffer in Intersim2 initialization with a wrong node number
 
 Version 3.2.3 versus 3.2.2
 - Bug fixes:

--- a/src/intersim2/interconnect_interface.cpp
+++ b/src/intersim2/interconnect_interface.cpp
@@ -364,7 +364,7 @@ Flit* InterconnectInterface::GetEjectedFlit(int subnet, int node)
 
 void InterconnectInterface::_CreateBuffer()
 {
-  unsigned nodes = _n_shader + _n_mem;
+  unsigned nodes = _net[0]->NumNodes();
 
   _boundary_buffer.resize(_subnets);
   _ejection_buffer.resize(_subnets);


### PR DESCRIPTION
Fixed bug #88. Initial ejection buffer and boundary buffer with the interconnection node number

See bug at:
http://www.gpgpu-sim.org/bugs/show_bug.cgi?id=88
