### PR TITLE
Getting rid of all the intermediate files that get generated into the source directory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ Version 3.2.3+edits (development branch) versus 3.2.3
 - Added support for bar.arrive and bar.red instructions.
 - Initial support for CUDA 5.0,5.5 and 6.0 to get template running.
 - Removed intersim2 svn repository files
+- Changed the makefile for cuobjdump_toptxplus,libcuda,intersim2 so that it outputs temporary files into the build directory
  
 - Bug fixes:
     - Fixed bug #81, fix ordering of pushing branch entries to the stack

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -27,39 +27,50 @@ $(OUTPUT_DIR)/cuobjdump_to_ptxplus: $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/
 	${LD} ${LDFLAGS} -o $@ $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/cuobjdumpInstList.o $(OUTPUT_DIR)/cuobjdump_to_ptxplus.o $(PTX_PARSER_OBJECTS) $(SASS_PARSER_OBJECTS) $(ELF_PARSER_OBJECTS) $(HEADER_PARSER_OBJECTS)
 
 
-lex.ptx_.c : ../src/cuda-sim/ptx.l
-	${LEX} ${LEXFLAGS} ../src/cuda-sim/ptx.l 
+$(OUTPUT_DIR)/lex.ptx_.c : ../src/cuda-sim/ptx.l
+	${LEX} ${LEXFLAGS} -o$(OUTPUT_DIR)/lex.ptx_.c ../src/cuda-sim/ptx.l
 
-ptx.tab.c : ../src/cuda-sim/ptx.y
-	${YACC} ${YFLAGS} --name-prefix=ptx_ -v ../src/cuda-sim/ptx.y 
+$(OUTPUT_DIR)/ptx.tab.c : ../src/cuda-sim/ptx.y
+	${YACC} ${YFLAGS} --name-prefix=ptx_ -v ../src/cuda-sim/ptx.y  --file-prefix=$(OUTPUT_DIR)/ptx
 
-ptx.tab.h : ptx.tab.c
+$(OUTPUT_DIR)/ptx.tab.h :$(OUTPUT_DIR)/ptx.tab.c
 
-$(OUTPUT_DIR)/lex.ptx_.o : lex.ptx_.c ptx.tab.h
-	${CXX} ${CXXFLAGS} -c lex.ptx_.c -o $@
+$(OUTPUT_DIR)/lex.ptx_.o : $(OUTPUT_DIR)/lex.ptx_.c $(OUTPUT_DIR)/ptx.tab.h
+	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/lex.ptx_.c -o $@
 
-$(OUTPUT_DIR)/ptx.tab.o : ptx.tab.c ptx_parser.h
-	${CXX} ${CXXFLAGS} -c ptx.tab.c -o $@
+$(OUTPUT_DIR)/ptx.tab.o : $(OUTPUT_DIR)/ptx.tab.c ptx_parser.h
+	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/ptx.tab.c -o $@
 
-
-%_lexer.cc: %.l %_parser.hh
+$(OUTPUT_DIR)/%_lexer.cc: %.l $(OUTPUT_DIR)/%_parser.hh
 	$(LEX) $(LEXFLAGS) -P $*_ -o$@ $<
 
-%_parser.cc: %.y
-	$(YACC) $(YFLAGS) -p $*_ -o$@ $<
+$(OUTPUT_DIR)/%_parser.cc: %.y
+	$(YACC) $(YFLAGS) -p $*_ -o$@ $< --file-prefix=$(OUTPUT_DIR)/$@
 
 # The ':' is needed otherwise make gets confused and doesn't understand that it knows how to make %Parser.hpp from %Parser.cpp.
 # : in bash is equivalent to NOP (no operation)
-%_parser.hh: %_parser.cc
+$(OUTPUT_DIR)/%_parser.hh: $(OUTPUT_DIR)/%_parser.cc
+	:
+
+$(OUTPUT_DIR)/%_parser.hh: %_parser.cc
 	:
 
 $(OUTPUT_DIR)/%.o: %.cc
 	$(CXX) ${CXXFLAGS} -c -o $@ $<
 
+$(OUTPUT_DIR)/%.o: $(OUTPUT_DIR)/%.cc
+	$(CXX) ${CXXFLAGS} -c -o $@ $<
+
 $(OUTPUT_DIR)/%.o: %.cpp %.h
 	$(CXX) ${CXXFLAGS} -c -o $@ $<
 
+$(OUTPUT_DIR)/%.o: $(OUTPUT_DIR)/%.cpp $(OUTPUT_DIR)/%.h
+	$(CXX) ${CXXFLAGS} -c -o $@ $<
+
 $(OUTPUT_DIR)/%.o: %.c %.h
+	${CXX} ${CCFLAGS} -c -o $@ $<
+
+$(OUTPUT_DIR)/%.o: $(OUTPUT_DIR)/%.c $(OUTPUT_DIR)/%.h
 	${CXX} ${CCFLAGS} -c -o $@ $<
 
 SRCS = $(shell ls *.cc)
@@ -79,4 +90,3 @@ clean:
 	rm -f $(OUTPUT_DIR)/Makefile.makedepend $(OUTPUT_DIR)/Makefile.makedepend.bak
 
 include $(OUTPUT_DIR)/Makefile.makedepend
-

--- a/libcuda/Makefile
+++ b/libcuda/Makefile
@@ -108,20 +108,23 @@ lib$(PROG).a: $(OBJS)
 	ar rcs $(OUTPUT_DIR)/lib$(PROG).a $(OBJS)
 
 $(OUTPUT_DIR)/%.o: %.cc
-	$(CPP) $(CXXFLAGS) -I./ -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
+	$(CPP) $(CXXFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
 
 $(OUTPUT_DIR)/%.o: %.c
-	$(CC) $(CCFLAGS) -I./ -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
+	$(CC) $(CCFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
 
-cuobjdump_parser.c: cuobjdump.y
-	$(YACC) $(YFLAGS) -p cuobjdump_ -o$@ $<
+$(OUTPUT_DIR)/%.o: $(OUTPUT_DIR)/%.c
+	$(CC) $(CCFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
 
-cuobjdump_lexer.c: cuobjdump.l cuobjdump_parser.h
+$(OUTPUT_DIR)/cuobjdump_parser.c: cuobjdump.y
+	$(YACC) $(YFLAGS) -p cuobjdump_  -o$@ $< --file-prefix=$(OUTPUT_DIR)/cuobjdump
+
+$(OUTPUT_DIR)/cuobjdump_lexer.c: cuobjdump.l $(OUTPUT_DIR)/cuobjdump_parser.h
 	$(LEX) $(LEXFLAGS) -P cuobjdump_ -o$@ $<
 	
 # The next rule means just get parser.c and you will get parser.h with it
 # in other words, get parser.c and do nothing to get parser.h
-%_parser.h: %_parser.c
+$(OUTPUT_DIR)/%_parser.h: $(OUTPUT_DIR)/%_parser.c
 	:
 $(OUTPUT_DIR)/Makefile.makedepend: depend
 

--- a/src/intersim2/Makefile
+++ b/src/intersim2/Makefile
@@ -126,10 +126,10 @@ endif
 # rules to compile simulator
 
 
-${LEX_OBJS}: lex.yy.c y.tab.h
+${LEX_OBJS}: $(OBJDIR)/lex.yy.c $(OBJDIR)/y.tab.h
 	$(CC) $(CPPFLAGS) -c $< -o $@
 
-${YACC_OBJS}: y.tab.c y.tab.h
+${YACC_OBJS}: $(OBJDIR)/y.tab.c $(OBJDIR)/y.tab.h
 	$(CC) $(CPPFLAGS) -c $< -o $@
 
 ${OBJDIR}/%.o: %.cpp 
@@ -168,8 +168,8 @@ clean:
 	rm -f y.tab.c y.tab.h lex.yy.c
 	rm -f moc_bgui.cpp
 
-y.tab.c y.tab.h: config.y
-	$(YACC) -d $<
+$(OBJDIR)/y.tab.c $(OBJDIR)/y.tab.h: config.y
+	$(YACC) -d $< --file-prefix=$(OBJDIR)/y
 
-lex.yy.c: config.l
-	$(LEX) $<
+$(OBJDIR)/lex.yy.c: config.l
+	$(LEX) -o$@ $<


### PR DESCRIPTION
Having lex and yacc generate to the source directory causes issues when trying to build multiple configs at the same time from the same source. Now the files go into the ./build/ directory - just like everything else that gets generated in the build process. It also make the cleanup process much easier because all you have to do is delete the ./build directory and everything is clean