### PR TITLE
Naive fix of OpenCL parse errors

### DIFF
--- a/src/cuda-sim/ptx.l
+++ b/src/cuda-sim/ptx.l
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ptx.tab.h"
 #include <string.h>
 
-char linebuf[1024];
+char linebuf[4096];
 unsigned col = 0;
 #define TC col+=strlen(ptx_text); 
 #define CHECK_UNSIGNED \
@@ -370,7 +370,7 @@ breakaddr  TC; ptx_lval.int_value = BREAKADDR_OP; return OPCODE;
 
 "//"[^\n]* TC;	// eat single
 
-\n.*  col=0; strncpy(linebuf, yytext + 1, 1024); yyless( 1 );
+\n.*  col=0; strncpy(linebuf, yytext + 1, sizeof(linebuf)); yyless( 1 );
 
 " " TC;
 "\t" TC;

--- a/src/cuda-sim/ptx.y
+++ b/src/cuda-sim/ptx.y
@@ -259,6 +259,7 @@ ptr_spec: /*empty*/
 ptr_space_spec: GLOBAL_DIRECTIVE { add_ptr_spec(global_space); }
               | LOCAL_DIRECTIVE  { add_ptr_spec(local_space); }
               | SHARED_DIRECTIVE { add_ptr_spec(shared_space); }
+			  | CONST_DIRECTIVE { add_ptr_spec(global_space); }
 
 ptr_align_spec: ALIGN_DIRECTIVE INT_OPERAND
 

--- a/src/cuda-sim/ptx.y
+++ b/src/cuda-sim/ptx.y
@@ -320,6 +320,7 @@ var_spec_list: var_spec
 var_spec: space_spec 
 	| type_spec
 	| align_spec
+	| VISIBLE_DIRECTIVE
 	| EXTERN_DIRECTIVE { add_extern_spec(); }
 	;
 

--- a/src/cuda-sim/ptx_parser.cc
+++ b/src/cuda-sim/ptx_parser.cc
@@ -240,7 +240,7 @@ void parse_assert_impl( int test_value, const char *file, unsigned line, const c
       parse_error_impl(file,line, msg);
 }
 
-extern char linebuf[1024];
+extern char linebuf[4096];
 
 
 void set_return()


### PR DESCRIPTION
Hello

I was trying to simulate an OpenCL kernel with your simulator but ran into some weird parse errors of valid OpenCL code:
- Long lines were truncated, so I increased the buffer size. I don't know if this has any real effect on the parsing or just affects the debugging lines.
- Arrays in the constant memory space (such as `constant float arr[10]`) are translated in the PTX as `.visible .const .align 4 .b8 arr[40]`. However, the PTX grammar doesn't seem to like that `.visible` specificator. I added a rule to allow that specificator in the `var_spec` rule, I don't know if further modifications should be done.
- When passing arguments to the kernel in the constant memory space, (such as `mykernel(constant float* arg)`) the grammar chokes on the _const_ specificator. I changed it to allow the _const_ specificator, indicating that it should be stored in the global memory space as per the [specification](https://www.khronos.org/registry/cl/sdk/1.1/docs/man/xhtml/constant.html).

[Here is an OpenCL sample](https://github.com/gjulianm/gpgpu-sim_distribution/raw/temp/gpgpu-sim_OpenCL-parse-errors.tar.gz) to demonstrate those issues. This is valid OpenCL code that doesn't build on your simulator, but seems to work with my fixes. However, I don't know if my fixes are breaking other parts of your code.

By the way, thanks for creating your simulator and open-sourcing it, it's really useful.

Greetings
