### PR TITLE
Initial support for 7.5 - tested on simple sdk benchmaks (e.g., template, vectorAdd, ...)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Version 3.2.3+edits (development branch) versus 3.2.3
   the two default cache sizes, 16KB/48KB with 32/64 sets.
 - Added support for named barriers.
 - Added support for bar.arrive and bar.red instructions.
-- Initial support for CUDA 5.0,5.5,6.0 and 7.5 to get basic sdk running (e.g., template, vectorAdd, ...). The issues required for CUDA 5.5 support were identified by the loneStarGPU group at  The University of Texas at Austin
+- Initial support for CUDA 5.0,5.5,6.0 and 7.5 to get basic sdk running (e.g., template, vectorAdd, ...). The issues required for CUDA 5.5 support were identified by the loneStarGPU group at The University of Texas at Austin and Texas State University.
 - Removed intersim2 svn repository files
 - Changed the makefile for cuobjdump_toptxplus,libcuda,intersim2 so that it outputs temporary files into the build directory
 - Bug fixes:

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ Version 3.2.3+edits (development branch) versus 3.2.3
   the two default cache sizes, 16KB/48KB with 32/64 sets.
 - Added support for named barriers.
 - Added support for bar.arrive and bar.red instructions.
-- Initial support for CUDA 5.0,5.5,6.0 and 7.5 to get basic sdk running (e.g., template, vectorAdd, ...)
+- Initial support for CUDA 5.0,5.5,6.0 and 7.5 to get basic sdk running (e.g., template, vectorAdd, ...). The issues required for CUDA 5.5 support were identified by the loneStarGPU group at  The University of Texas at Austin
 - Removed intersim2 svn repository files
 - Changed the makefile for cuobjdump_toptxplus,libcuda,intersim2 so that it outputs temporary files into the build directory
 - Bug fixes:

--- a/CHANGES
+++ b/CHANGES
@@ -5,10 +5,13 @@ Version 3.2.3+edits (development branch) versus 3.2.3
   the two default cache sizes, 16KB/48KB with 32/64 sets.
 - Added support for named barriers.
 - Added support for bar.arrive and bar.red instructions.
-- Initial support for CUDA 5.0,5.5 and 6.0 to get template running.
+- Initial support for CUDA 5.0,5.5,6.0 and 7.5 to get basic sdk running (e.g., template, vectorAdd, ...)
 - Removed intersim2 svn repository files
 - Changed the makefile for cuobjdump_toptxplus,libcuda,intersim2 so that it outputs temporary files into the build directory
- 
+- Bug fixes:
+    - Fixed a bug where sm_version was hard coded to sm_20. Now, it extracts the highest sm version that is lower than
+      the forced_max_capability configuration in GPGPUSim. 
+
 - Bug fixes:
     - Fixed bug #81, fix ordering of pushing branch entries to the stack
     - Fixed a bug where for each icache miss we also count a hit

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.5.0 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.5.0; fi
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.5.5 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.5.5; fi
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.6.0 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.6.0; fi
-
+	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.7.5 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.7.5; fi
 $(SIM_LIB_DIR)/libcudart.dylib: makedirs $(LIBS) cudalib
 	g++ -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.1,-current_version,1.1\
 			$(SIM_OBJ_FILES_DIR)/libcuda/*.o \

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1525,7 +1525,7 @@ cuobjdumpPTXSection* findPTXSectionInList(std::list<cuobjdumpSection*> sectionli
 	){
 		cuobjdumpPTXSection* ptxsection;
 		if((ptxsection=dynamic_cast<cuobjdumpPTXSection*>(*iter)) != NULL){
-			if(ptxsection->getIdentifier() == identifier)
+			//if(ptxsection->getIdentifier() == identifier)
 				return ptxsection;
 		}
 	}

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1484,6 +1484,8 @@ std::list<cuobjdumpSection*> pruneSectionList(std::list<cuobjdumpSection*> cuobj
 			delete *iter;
 		}
 	}
+
+	assert(!prunedList.empty() && "WARNING: Change -gpgpu_ptx_force_max_capability in gpgpusim.config to match the largest Gencode argument in the Makefile");
 	return prunedList;
 }
 

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1533,7 +1533,7 @@ cuobjdumpPTXSection* findPTXSectionInList(std::list<cuobjdumpSection*> sectionli
 	){
 		cuobjdumpPTXSection* ptxsection;
 		if((ptxsection=dynamic_cast<cuobjdumpPTXSection*>(*iter)) != NULL){
-			//if(ptxsection->getIdentifier() == identifier)
+			if(ptxsection->getIdentifier() == identifier)
 				return ptxsection;
 		}
 	}
@@ -1632,10 +1632,13 @@ void** CUDARTAPI __cudaRegisterFatBinary( void *fatCubin )
 		// - Obtains the pointer to the actual fatbin structure from the FatBin handle (fatCubin).
 		// - An integer inside the fatbin structure contains the relative offset to the source code file name.
 		// - This offset differs among different CUDA and GCC versions. 
+		#if (CUDART_VERSION <= 6000)
 		char * pfatbin = (char*) fatDeviceText->d; 
 		int offset = *((int*)(pfatbin+48)); 
 		char * filename = (pfatbin+16+offset); 
-
+		#else
+		char * filename = "default";
+		#endif
 		// The extracted file name is associated with a fat_cubin_handle passed
 		// into cudaLaunch().  Inside cudaLaunch(), the associated file name is
 		// used to find the PTX/SASS section from cuobjdump, which contains the

--- a/libcuda/cuobjdump.l
+++ b/libcuda/cuobjdump.l
@@ -55,8 +55,9 @@ void cuobjdump_error(const char*);
 %s elfheader
 %s ptxheader
 %s endheader
-%s identifier
-%s identifierF
+%x identifier
+%x conidentifier
+%s endidentifier
 
 alpha		[a-zA-Z]
 numeric		[0-9]
@@ -101,10 +102,16 @@ newlines	{newline}+
 	/*SASS code tokens*/
 <sasscode>{notnewline}*{newline} yylval.string_value = strdup(yytext); return SASSLINE;
 
-<identifier>"identifier = "	BEGIN(identifierF); return H_IDENTIFIER;
-<identifier>"\n" yy_pop_state();
+<identifier>{newline}"compressed"{newline}	BEGIN(conidentifier); return H_COMPRESSED;
+<identifier>{newline}"identifier = "	BEGIN(endidentifier); return H_IDENTIFIER;
+<identifier>{newline}{newline} yy_pop_state();
 
-<identifierF>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME;
+
+<conidentifier>"identifier = "	BEGIN(endidentifier); return H_IDENTIFIER;
+<conidentifier>{newline} yy_pop_state();
+
+
+<endidentifier>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME;
 
 
 
@@ -128,8 +135,7 @@ newlines	{newline}+
 <ptxheader>\[{numeric},{numeric}\]	return CODEVERSION;
 <ptxheader>"producer = "		return H_PRODUCER;
 <ptxheader>"host = "			return H_HOST;
-<ptxheader>"compile_size = "	return H_COMPILESIZE;
-<ptxheader>"compressed"{newline}		yy_pop_state(); return H_COMPRESSED;
+<ptxheader>"compile_size = "	BEGIN(endheader); return H_COMPILESIZE;
 
 
 

--- a/libcuda/cuobjdump.l
+++ b/libcuda/cuobjdump.l
@@ -52,8 +52,11 @@ void cuobjdump_error(const char*);
 %s ptxcode
 %s sasscode
 %s elfcode
-%s header
+%s elfheader
+%s ptxheader
 %s endheader
+%s identifier
+%s identifierF
 
 alpha		[a-zA-Z]
 numeric		[0-9]
@@ -67,16 +70,20 @@ newlines	{newline}+
 "ptxasOptions"{notnewline}*{newline}
 [1-9]{numeric}* yylval.string_value = strdup(yytext); return DECIMAL;
 
+"has debug info"{newline}
+
 
 "Fatbin ptx code:"{newline}	{
 	yy_push_state(ptxcode);
-	yy_push_state(header);
+	yy_push_state(identifier);
+	yy_push_state(ptxheader);
 	yylval.string_value = strdup(yytext);
 	return PTXHEADER;
 }
 "Fatbin elf code:"{newline}	{
 	yy_push_state(elfcode);
-	yy_push_state(header);
+	yy_push_state(identifier);
+	yy_push_state(elfheader);
 	yylval.string_value = strdup(yytext);
 	return ELFHEADER;
 }
@@ -94,22 +101,45 @@ newlines	{newline}+
 	/*SASS code tokens*/
 <sasscode>{notnewline}*{newline} yylval.string_value = strdup(yytext); return SASSLINE;
 
+<identifier>"identifier = "	BEGIN(identifierF); return H_IDENTIFIER;
+<identifier>"\n" yy_pop_state();
+
+<identifierF>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME;
+
+
+
 	/*Header tokens*/
-<header>[[:alnum:]_]+ yylval.string_value = strdup(yytext); return IDENTIFIER;
-<header>"================"	return H_SEPARATOR;
-<header>"arch = "		return H_ARCH;
-<header>"code version = "	return H_CODEVERSION;
-<header>\[{numeric},{numeric}\]	return CODEVERSION;
-<header>"producer = "		return H_PRODUCER;
-<header>"host = "			return H_HOST;
-<header>"compile_size = "	return H_COMPILESIZE;
-<header>"compressed"{newline}
-<header>"identifier = "		BEGIN(endheader); return H_IDENTIFIER;
-<header>"has debug info"{newline}
+<elfheader>[[:alnum:]_]+ yylval.string_value = strdup(yytext); return IDENTIFIER;
+<elfheader>"================"	return H_SEPARATOR;
+<elfheader>"arch = "		return H_ARCH;
+<elfheader>"code version = "	return H_CODEVERSION;
+<elfheader>\[{numeric},{numeric}\]	return CODEVERSION;
+<elfheader>"producer = "		return H_PRODUCER;
+<elfheader>"<unknown>"			return H_UNKNOWN;
+<elfheader>"host = "			return H_HOST;
+<elfheader>"compile_size = "	BEGIN(endheader); return H_COMPILESIZE;
+
+
+	/*Header tokens*/
+<ptxheader>[[:alnum:]_]+ yylval.string_value = strdup(yytext); return IDENTIFIER;
+<ptxheader>"================"	return H_SEPARATOR;
+<ptxheader>"arch = "		return H_ARCH;
+<ptxheader>"code version = "	return H_CODEVERSION;
+<ptxheader>\[{numeric},{numeric}\]	return CODEVERSION;
+<ptxheader>"producer = "		return H_PRODUCER;
+<ptxheader>"host = "			return H_HOST;
+<ptxheader>"compile_size = "	return H_COMPILESIZE;
+<ptxheader>"compressed"{newline}		yy_pop_state(); return H_COMPRESSED;
+
+
+
+
+
 
 	/* Looking for the identifier (filename) then the header is done */
 	/* <endheader>[[:alnum:]_\./]+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME; */
-<endheader>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME;
+<endheader>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return IDENTIFIER;
+
 
 
 {newline}	return NEWLINE;

--- a/libcuda/cuobjdump.y
+++ b/libcuda/cuobjdump.y
@@ -39,7 +39,7 @@ void setCuobjdumpelffilename(const char* filename);
 void setCuobjdumpsassfilename(const char* filename);
 int elfserial = 1;
 int ptxserial = 1;
-int yydebug=1;
+
 FILE *ptxfile;
 FILE *elffile;
 FILE *sassfile;

--- a/libcuda/cuobjdump.y
+++ b/libcuda/cuobjdump.y
@@ -39,7 +39,7 @@ void setCuobjdumpelffilename(const char* filename);
 void setCuobjdumpsassfilename(const char* filename);
 int elfserial = 1;
 int ptxserial = 1;
-
+int yydebug = 1;
 FILE *ptxfile;
 FILE *elffile;
 FILE *sassfile;
@@ -75,7 +75,7 @@ section :	PTXHEADER {
 				snprintf(filename, 1024, "_cuobjdump_%d.ptx", ptxserial++);
 				ptxfile = fopen(filename, "w");
 				setCuobjdumpptxfilename(filename);
-			} headerinfo identifier ptxcode {
+			} headerinfo compressedkeyword identifier ptxcode {
 				fclose(ptxfile);
 			}
 		|	ELFHEADER {
@@ -84,6 +84,7 @@ section :	PTXHEADER {
 				elffile = fopen(filename, "w");
 				setCuobjdumpelffilename(filename);
 			} headerinfo identifier{
+				printf("\nHeader Info and Identifier Parsed\n");
 			} elfcode {
 				fclose(elffile);
 				snprintf(filename, 1024, "_cuobjdump_%d.sass", elfserial++);
@@ -98,23 +99,19 @@ headerinfo :	H_SEPARATOR NEWLINE
 				H_CODEVERSION CODEVERSION NEWLINE
 				H_PRODUCER H_UNKNOWN NEWLINE
 				H_HOST IDENTIFIER NEWLINE
-				H_COMPILESIZE IDENTIFIER emptylines {setCuobjdumparch($4);};
+				H_COMPILESIZE IDENTIFIER  {setCuobjdumparch($4);};
 			|   H_SEPARATOR NEWLINE
 				H_ARCH IDENTIFIER NEWLINE
 				H_CODEVERSION CODEVERSION NEWLINE
 				H_PRODUCER IDENTIFIER NEWLINE
 				H_HOST IDENTIFIER NEWLINE
-				H_COMPILESIZE IDENTIFIER emptylines {setCuobjdumparch($4);};
-			|   H_SEPARATOR NEWLINE
-				H_ARCH IDENTIFIER NEWLINE
-				H_CODEVERSION CODEVERSION NEWLINE
-				H_PRODUCER IDENTIFIER NEWLINE
-				H_HOST IDENTIFIER NEWLINE
-				H_COMPILESIZE IDENTIFIER NEWLINE 
-				H_COMPRESSED  emptylines		{setCuobjdumparch($4);};		
+				H_COMPILESIZE IDENTIFIER {setCuobjdumparch($4);};
 
-identifier : H_IDENTIFIER FILENAME {setCuobjdumpidentifier($2);};
+identifier : H_IDENTIFIER FILENAME emptylines {setCuobjdumpidentifier($2);};
 			 |	;
+
+compressedkeyword : H_COMPRESSED emptylines
+                    | ;
 
 ptxcode :	ptxcode PTXLINE {fprintf(ptxfile, "%s", $2);}
 		|	;

--- a/libcuda/cuobjdump.y
+++ b/libcuda/cuobjdump.y
@@ -39,7 +39,6 @@ void setCuobjdumpelffilename(const char* filename);
 void setCuobjdumpsassfilename(const char* filename);
 int elfserial = 1;
 int ptxserial = 1;
-int yydebug = 1;
 FILE *ptxfile;
 FILE *elffile;
 FILE *sassfile;
@@ -84,7 +83,6 @@ section :	PTXHEADER {
 				elffile = fopen(filename, "w");
 				setCuobjdumpelffilename(filename);
 			} headerinfo identifier{
-				printf("\nHeader Info and Identifier Parsed\n");
 			} elfcode {
 				fclose(elffile);
 				snprintf(filename, 1024, "_cuobjdump_%d.sass", elfserial++);
@@ -107,8 +105,8 @@ headerinfo :	H_SEPARATOR NEWLINE
 				H_HOST IDENTIFIER NEWLINE
 				H_COMPILESIZE IDENTIFIER {setCuobjdumparch($4);};
 
-identifier : H_IDENTIFIER FILENAME emptylines {setCuobjdumpidentifier($2);};
-			 |	;
+identifier : H_IDENTIFIER FILENAME emptylines {setCuobjdumpidentifier($2);}
+			 |	{setCuobjdumpidentifier("default");};
 
 compressedkeyword : H_COMPRESSED emptylines
                     | ;

--- a/libopencl/opencl_runtime_api.cc
+++ b/libopencl/opencl_runtime_api.cc
@@ -268,7 +268,7 @@ cl_int _cl_kernel::bind_args( gpgpu_ptx_sim_arg_list_t &arg_list )
       if( i->first != k ) 
          return CL_INVALID_KERNEL_ARGS;
       arg_info arg = i->second;
-      gpgpu_ptx_sim_arg param( arg.m_arg_value, arg.m_arg_size, 0 );
+      gpgpu_ptx_sim_arg param( arg.m_arg_value, arg.m_arg_size, 0);
       arg_list.push_front( param );
       k++;
    }
@@ -575,7 +575,7 @@ void _cl_program::Build(const char *options)
       }
       info.m_asm = tmp;
       info.m_symtab = gpgpu_ptx_sim_load_ptx_from_string( tmp, source_num );
-      gpgpu_ptxinfo_load_from_string( tmp, source_num );
+      gpgpu_ptxinfo_load_from_string( tmp, source_num);
       free(tmp);
    }
    printf("GPGPU-Sim OpenCL API: finished compiling OpenCL kernels.\n"); 

--- a/setup_environment
+++ b/setup_environment
@@ -43,7 +43,7 @@ CC_VERSION=`gcc --version | head -1 | awk '{for(i=1;i<=NF;i++){ if(match($i,/^[0
 
 CUDA_VERSION_STRING=`$CUDA_INSTALL_PATH/bin/nvcc --version | awk '/release/ {print $5;}' | sed 's/,//'`;
 CUDA_VERSION_NUMBER=`echo $CUDA_VERSION_STRING | sed 's/\./ /' | awk '{printf("%02u%02u", 10*int($1), 10*$2);}'`
-if [ $CUDA_VERSION_NUMBER -gt 6000 -o $CUDA_VERSION_NUMBER -lt 2030  ]; then
+if [ $CUDA_VERSION_NUMBER -gt 7500 -o $CUDA_VERSION_NUMBER -lt 2030  ]; then
 	echo "ERROR ** GPGPU-Sim version $GPGPUSIM_VERSION_STRING not tested with CUDA version $CUDA_VERSION_STRING (please see README)";
 	return
 elif [ $CUDA_VERSION_NUMBER -gt 4020 ]; then

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -182,7 +182,7 @@ symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source
     return symtab;
 }
 
-void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version=20 )
+void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version )
 {
     char fname[1024];
     snprintf(fname,1024,"_ptx_XXXXXX");

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -182,7 +182,7 @@ symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source
     return symtab;
 }
 
-void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num )
+void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version=20 )
 {
     char fname[1024];
     snprintf(fname,1024,"_ptx_XXXXXX");
@@ -216,7 +216,8 @@ void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num
     extra_flags[0]=0;
 
 #if CUDART_VERSION >= 3000
-    snprintf(extra_flags,1024,"--gpu-name=sm_20");
+    if (sm_version == 0) sm_version = 20;
+    snprintf(extra_flags,1024,"--gpu-name=sm_%u",sm_version);
 #endif
 
     snprintf(commandline,1024,"$CUDA_INSTALL_PATH/bin/ptxas %s -v %s --output-file  /dev/null 2> %s",

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -32,7 +32,7 @@
 extern bool g_override_embedded_ptx;
  
 class symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num );
-void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version );
+void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version=20 );
 char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
 bool keep_intermediate_files();
 

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -32,7 +32,7 @@
 extern bool g_override_embedded_ptx;
  
 class symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num );
-void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num );
+void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version );
 char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
 bool keep_intermediate_files();
 


### PR DESCRIPTION
This an initial support for CUDA 7.5. It puts it at the same level of current GPGPUSim-dev support for 5.0, 5.5 and 6.0. This support is limited to ability to parse the headers correctly, thus, if the benchmark has PTX/SASS instuctions that is not yet supported it would fail.


Also, changes have been made to allow for configurable SM version.

Regression for 4.2 on GTX480 has run successful. For non-fully supported verions (>=5.5 and <=7.5), it was tested on simple sdk benchmarks. 

Attached are files that shows the cuobjdump output for different versions.

[template_75.txt](https://github.com/gpgpu-sim/gpgpu-sim_distribution/files/265056/template_75.txt)
[template_55.txt](https://github.com/gpgpu-sim/gpgpu-sim_distribution/files/265054/template_55.txt)
[template_42.txt](https://github.com/gpgpu-sim/gpgpu-sim_distribution/files/265055/template_42.txt)


