### PR TITLE
Fix next block addr to link predicate ret block to consecutive block

### DIFF
--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -498,7 +498,7 @@ void function_info::connect_basic_blocks( ) //iterate across m_basic_blocks of f
          if( pI->has_pred() ) {
             printf("GPGPU-Sim PTX: Warning detected predicated return/exit.\n");
             // if predicated, add link to next block
-            unsigned next_addr = pI->get_m_instr_mem_index() + 1;
+            unsigned next_addr = pI->get_m_instr_mem_index() + pI->inst_size();
             if( next_addr < m_instr_mem_size && m_instr_mem[next_addr] ) {
                basic_block_t *next_bb = m_instr_mem[next_addr]->get_bb();
                (*bb_itr)->successor_ids.insert(next_bb->bb_id);


### PR DESCRIPTION
The block containing predicate ret instruction should add the consecutive block to its successor_ids set. next_addr should be assigned with current instruction address adding instruction size instead of 1. Block connections can be print out to test whether block are correctly linked.

Signed-off-by: Mengchi Zhang <zhan2308@purdue.edu>