### PR TITLE
Embedding the gpgpu-sim version information (the commit number that was built) in the shared object executable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ no_opencl_support:
 	@echo "Warning: gpgpu-sim is building without opencl support. Make sure NVOPENCL_LIBDIR and NVOPENCL_INCDIR are set"
 
 $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
-	g++ -shared -Wl,-soname,libcudart.so \
+	g++ -shared -Wl,-soname,libcudart_$(GPGPUSIM_BUILD).so \
 			$(SIM_OBJ_FILES_DIR)/libcuda/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \
@@ -174,7 +174,7 @@ $(SIM_LIB_DIR)/libcudart.dylib: makedirs $(LIBS) cudalib
 			-o $(SIM_LIB_DIR)/libcudart.dylib
 
 $(SIM_LIB_DIR)/libOpenCL.so: makedirs $(LIBS) opencllib
-	g++ -shared -Wl,-soname,libOpenCL.so \
+	g++ -shared -Wl,-soname,libOpenCL_$(GPGPUSIM_BUILD).so \
 			$(SIM_OBJ_FILES_DIR)/libopencl/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ ifneq ($(shell which nvcc), "")
 	endif
 endif
 
+
+$(shell mkdir -p $(SIM_OBJ_FILES_DIR)/libcuda && echo "const char *g_gpgpusim_build_string=\"$(GPGPUSIM_BUILD)\";" > $(SIM_OBJ_FILES_DIR)/detailed_version)
+
 LIBS = cuda-sim gpgpu-sim_uarch $(INTERSIM) gpgpusimlib 
 
 

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -46,7 +46,7 @@ OPT	:=  -O3 -g3 -Wall -Wno-unused-function -Wno-sign-compare
 ifeq ($(DEBUG),1)
 	OPT := -g3 -Wall  -Wno-unused-function -Wno-sign-compare
 endif
-OPT += -I$(CUDA_INSTALL_PATH)/include  -I$(OUTPUT_DIR)/ -I.
+OPT += -I$(CUDA_INSTALL_PATH)/include  -I$(OUTPUT_DIR)/ -I. -I$(SIM_OBJ_FILES_DIR)
 OPT += -fPIC 
 
 ifeq ($(TRACE),1)

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -1623,14 +1623,13 @@ kernel_info_t *gpgpu_opencl_ptx_sim_init_grid(class function_info *entry,
 }
 
 #include "../../version"
+#include "detailed_version"
 
 void print_splash()
 {
    static int splash_printed=0;
    if ( !splash_printed ) {
-      unsigned build=0;
-      sscanf(g_gpgpusim_build_string, "$Change"": %u $", &build);
-      fprintf(stdout, "\n\n        *** %s [build %u] ***\n\n\n", g_gpgpusim_version_string, build );
+      fprintf(stdout, "\n\n        *** %s [build %s] ***\n\n\n", g_gpgpusim_version_string, g_gpgpusim_build_string );
       splash_printed=1;
    }
 }

--- a/version
+++ b/version
@@ -1,2 +1,1 @@
 const char *g_gpgpusim_version_string = "GPGPU-Sim Simulator Version 3.2.2 ";
-const char *g_gpgpusim_build_string   =  "$Change$"; 

--- a/version_detection.mk
+++ b/version_detection.mk
@@ -30,7 +30,13 @@
 ifeq ($(GPGPUSIM_ROOT),)
 else
 GPGPUSIM_VERSION=$(shell cat $(GPGPUSIM_ROOT)/version | awk '/Version/ {print $$8}' )
-GPGPUSIM_BUILD=$(shell cat $(GPGPUSIM_ROOT)/version | awk '/Change/ {print $$6}' )
+
+#Detect Git branch and commit #
+GIT_BRANCH := $(shell git branch | grep "\*" | sed -re 's/\*\s+(.*)/\1/')
+GIT_COMMIT := $(shell git log -n 1 | head -1 | sed -re 's/commit (.*)/\1/')
+GIT_FILES_CHANGED := $(shell git diff --numstat --cached && git diff --numstat | wc | sed -re 's/^\s+([0-9]+).*/\1/')
+GPGPUSIM_BUILD := "gpgpu-sim_$(GIT_BRANCH)_$(GIT_COMMIT)_modified_$(GIT_FILES_CHANGED)"
+$(shell mkdir -p $(SIM_OBJ_FILES_DIR)/libcuda && echo "const char *g_gpgpusim_build_string=\"$(GPGPUSIM_BUILD)\";" > $(SIM_OBJ_FILES_DIR)/detailed_version)
 endif
 
 # Detect CUDA Runtime Version 
@@ -42,4 +48,3 @@ CC_VERSION := $(shell gcc --version | head -1 | awk '{for(i=1;i<=NF;i++){ if(mat
 
 # Detect Support for C++11 (C++0x) from GCC Version 
 GNUC_CPP0X := $(shell gcc --version | perl -ne 'if (/gcc\s+\(.*\)\s+([0-9.]+)/){ if($$1 >= 4.3) {$$n=1} else {$$n=0;} } END { print $$n; }')
-

--- a/version_detection.mk
+++ b/version_detection.mk
@@ -32,10 +32,9 @@ else
 GPGPUSIM_VERSION=$(shell cat $(GPGPUSIM_ROOT)/version | awk '/Version/ {print $$8}' )
 
 #Detect Git branch and commit #
-GIT_BRANCH := $(shell git branch | grep "\*" | sed -re 's/\*\s+(.*)/\1/')
 GIT_COMMIT := $(shell git log -n 1 | head -1 | sed -re 's/commit (.*)/\1/')
 GIT_FILES_CHANGED := $(shell git diff --numstat --cached && git diff --numstat | wc | sed -re 's/^\s+([0-9]+).*/\1/')
-GPGPUSIM_BUILD := "gpgpu-sim_$(GIT_BRANCH)_$(GIT_COMMIT)_modified_$(GIT_FILES_CHANGED)"
+GPGPUSIM_BUILD := "gpgpu-sim_git-commit-$(GIT_COMMIT)_modified_$(GIT_FILES_CHANGED)"
 endif
 
 # Detect CUDA Runtime Version 

--- a/version_detection.mk
+++ b/version_detection.mk
@@ -36,7 +36,6 @@ GIT_BRANCH := $(shell git branch | grep "\*" | sed -re 's/\*\s+(.*)/\1/')
 GIT_COMMIT := $(shell git log -n 1 | head -1 | sed -re 's/commit (.*)/\1/')
 GIT_FILES_CHANGED := $(shell git diff --numstat --cached && git diff --numstat | wc | sed -re 's/^\s+([0-9]+).*/\1/')
 GPGPUSIM_BUILD := "gpgpu-sim_$(GIT_BRANCH)_$(GIT_COMMIT)_modified_$(GIT_FILES_CHANGED)"
-$(shell mkdir -p $(SIM_OBJ_FILES_DIR)/libcuda && echo "const char *g_gpgpusim_build_string=\"$(GPGPUSIM_BUILD)\";" > $(SIM_OBJ_FILES_DIR)/detailed_version)
 endif
 
 # Detect CUDA Runtime Version 


### PR DESCRIPTION
This has a bunch of potential uses, but it makes running simulations much easier because we can just print the exact git commit that this run of GPGPU-Sim was built for.
The primary motivator is to make it very clear when running simulations which version of GPGPU-Sim you ran.
Tested on CUDA 4.2 and hi-jacking the SONAME in the built exec does not seem to have a detrimental effect.