### PR TITLE
Fixing BankGroup Indexing Bug

### DIFF
--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -195,7 +195,7 @@ struct memory_config {
       for (i=0; nbkt>0; i++) {
           nbkt = nbkt>>1;
       }
-      bk_tag_length = i;
+      bk_tag_length = i-1;
       assert(nbkgrp>0 && "Number of bank groups cannot be zero");
       tRCDWR = tRCD-(WL+1);
       tRTW = (CL+(BL/data_command_freq_ratio)+2-WL);


### PR DESCRIPTION
Bug found and fixed by mahmoud - we were not using all the banks in the DRAM.
Pre-regressed by the purdue system.