### PR TITLE
Updating the interconnect simulator to properly check for dependencies

### DIFF
--- a/src/intersim2/Makefile
+++ b/src/intersim2/Makefile
@@ -125,6 +125,14 @@ endif
 
 # rules to compile simulator
 
+$(OBJDIR)/Makefile.makedepend: depend
+
+ALL_SRCS = $(CPP_SRCS)
+ALL_SRCS += $(shell ls **/*.cpp)
+
+depend:
+	touch $(OBJDIR)/Makefile.makedepend
+	makedepend -f$(OBJDIR)/Makefile.makedepend -I$(INCPATH) -p$(OBJDIR)/ $(ALL_SRCS) 2> /dev/null
 
 ${LEX_OBJS}: $(OBJDIR)/lex.yy.c $(OBJDIR)/y.tab.h
 	$(CC) $(CPPFLAGS) -c $< -o $@
@@ -173,3 +181,5 @@ $(OBJDIR)/y.tab.c $(OBJDIR)/y.tab.h: config.y
 
 $(OBJDIR)/lex.yy.c: config.l
 	$(LEX) -o$@ $<
+
+include $(OBJDIR)/Makefile.makedepend


### PR DESCRIPTION
Without this, incremental builds that change files that the interconnect is using in GPGPU-Sim will not trigger interconnect rebuilds - which leads to weird runtime problems because the interconnect was built with old headers.