### PR TITLE
Apps compiled with newer versions of CUDA want the version number embedded in the so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ no_opencl_support:
 	@echo "Warning: gpgpu-sim is building without opencl support. Make sure NVOPENCL_LIBDIR and NVOPENCL_INCDIR are set"
 
 $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
-	g++ -shared -Wl,-soname,libcudart_$(GPGPUSIM_BUILD).so \
+	g++ -shared -Wl,-soname,libcudart_$(GPGPUSIM_BUILD).so -Wl,--version-script=linux-so-version.txt\
 			$(SIM_OBJ_FILES_DIR)/libcuda/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \

--- a/linux-so-version.txt
+++ b/linux-so-version.txt
@@ -1,0 +1,2 @@
+libcudart.so.9.1{
+};


### PR DESCRIPTION
There does not seem to be a hard requirement on what the number is, only that it is there.