### PR TITLE
Provide portable (non-x86) breakpoint method which should work on all…

### DIFF
--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <signal.h>
 #include "zlib.h"
 
 
@@ -1440,7 +1441,7 @@ void gpgpu_sim::cycle()
 
 
       if( g_single_step && ((gpu_sim_cycle+gpu_tot_sim_cycle) >= g_single_step) ) {
-          asm("int $03");
+          raise(SIGTRAP); // Debug breakpoint
       }
       gpu_sim_cycle++;
       if( g_interactive_debugger_enabled ) 


### PR DESCRIPTION
calling INT#3 for breakpoints only works on x86. Raising SIGTRAP should work on all Linux machines. (tested on PowerPC).

Note that other Makefile changes are required to get it to compile on non-Intel platforms. These other changes are in my dev-cleanup branch.