### PR TITLE
Cleanup clang warnings

### DIFF
--- a/cuobjdump_to_ptxplus/cuobjdumpInst.cc
+++ b/cuobjdump_to_ptxplus/cuobjdumpInst.cc
@@ -2083,7 +2083,7 @@ void cuobjdumpInst::printCuobjdumpPtxPlus(std::list<std::string> labelList, std:
 	else
 	{
 		printf("Unknown Instruction: ");
-		printf(m_base.c_str());
+		printf("%s",m_base.c_str());
 		printf("\n");
 		output("Unknown Instruction: ");
 		output(m_base);

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -324,7 +324,7 @@ private:
 	gpgpu_ptx_sim_arg_list_t m_args;
 };
 
-class _cuda_device_id *GPGPUSim_Init()
+struct _cuda_device_id *GPGPUSim_Init()
 {
 	static _cuda_device_id *the_device = NULL;
 	if( !the_device ) {

--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -67,6 +67,8 @@
 #ifndef CUDA_MATH
 #define CUDA_MATH
 
+#include <cmath>
+
 // cuda math implementations
 #undef max
 #undef min

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -2067,7 +2067,7 @@ struct rec_pts {
    int s_num_recon;
 };
 
-struct std::map<function_info*,rec_pts> g_rpts;
+class std::map<function_info*,rec_pts> g_rpts;
 
 struct rec_pts find_reconvergence_points( function_info *finfo )
 {

--- a/src/cuda-sim/ptx_ir.h
+++ b/src/cuda-sim/ptx_ir.h
@@ -105,7 +105,7 @@ private:
    int m_is_function;
    bool m_is_non_arch_reg;
 
-   friend class type_info_key_compare;
+   friend struct type_info_key_compare;
 };
 
 class symbol_table;

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -222,7 +222,7 @@ void gpgpu_sim::gpgpu_debug()
    }
 }
 
-bool thread_at_brkpt( ptx_thread_info *thread, const struct brk_pt &b )
+bool thread_at_brkpt( ptx_thread_info *thread, const class brk_pt &b )
 {
    return b.is_equal(thread->get_location(),thread->get_uid());
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -87,7 +87,7 @@ extern int gpgpu_ptx_instruction_classification ;
 
 class ptx_thread_info;
 class ptx_instruction;
-bool thread_at_brkpt( ptx_thread_info *thd_info, const struct brk_pt &b );
+bool thread_at_brkpt( ptx_thread_info *thd_info, const class brk_pt &b );
 void hit_watchpoint( unsigned watchpoint_num, ptx_thread_info *thd, const ptx_instruction *pI );
 
 #endif

--- a/src/gpgpu-sim/dram.h
+++ b/src/gpgpu-sim/dram.h
@@ -87,7 +87,7 @@ struct bank_t
    unsigned int bkgrpindex;
 };
 
-struct mem_fetch;
+class mem_fetch;
 
 class dram_t 
 {
@@ -178,7 +178,7 @@ private:
    unsigned int ave_mrqs_partial;
    unsigned int bwutil_partial;
 
-   struct memory_stats_t *m_stats;
+   class memory_stats_t *m_stats;
    class Stats* mrqq_Dist; //memory request queue inside DRAM  
 
    friend class frfcfs_scheduler;

--- a/src/gpgpu-sim/mem_fetch.cc
+++ b/src/gpgpu-sim/mem_fetch.cc
@@ -39,7 +39,7 @@ mem_fetch::mem_fetch( const mem_access_t &access,
                       unsigned wid,
                       unsigned sid, 
                       unsigned tpc, 
-                      const class memory_config *config )
+                      const struct memory_config *config )
 {
    m_request_uid = sm_next_mf_request_uid++;
    m_access = access;

--- a/src/gpgpu-sim/mem_fetch.h
+++ b/src/gpgpu-sim/mem_fetch.h
@@ -55,7 +55,7 @@ public:
                unsigned wid,
                unsigned sid, 
                unsigned tpc, 
-               const class memory_config *config );
+               const struct memory_config *config );
    ~mem_fetch();
 
    void set_status( enum mem_fetch_status status, unsigned long long cycle );
@@ -141,7 +141,7 @@ private:
 
    static unsigned sm_next_mf_request_uid;
 
-   const class memory_config *m_mem_config;
+   const struct memory_config *m_mem_config;
    unsigned icnt_flit_size;
 };
 

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -286,7 +286,7 @@ typedef std::bitset<WARP_PER_CTA_MAX> warp_set_t;
 int register_bank(int regnum, int wid, unsigned num_banks, unsigned bank_warp_shift);
 
 class shader_core_ctx;
-class shader_core_config;
+struct shader_core_config;
 class shader_core_stats;
 
 enum scheduler_prioritization_type
@@ -967,7 +967,7 @@ struct ifetch_buffer_t {
     unsigned m_warp_id;
 };
 
-class shader_core_config;
+struct shader_core_config;
 
 class simd_function_unit {
 public:

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1347,7 +1347,7 @@ struct shader_core_config : public core_config
 
 struct shader_core_stats_pod {
 
-	void* shader_core_stats_pod_start[]; // DO NOT MOVE FROM THE TOP - spaceless pointer to the start of this structure
+	void* shader_core_stats_pod_start[0]; // DO NOT MOVE FROM THE TOP - spaceless pointer to the start of this structure
 	unsigned long long *shader_cycles;
     unsigned *m_num_sim_insn; // number of scalar thread instructions committed by this shader core
     unsigned *m_num_sim_winsn; // number of warp instructions committed by this shader core

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -93,7 +93,7 @@ public:
         m_stream=stream;
         m_done=false;
     }
-    stream_operation( class CUevent_st *e, struct CUstream_st *stream )
+    stream_operation( struct CUevent_st *e, struct CUstream_st *stream )
     {
         m_kernel=NULL;
         m_type=stream_event;
@@ -172,10 +172,10 @@ private:
 
     bool m_sim_mode;
     kernel_info_t *m_kernel;
-    class CUevent_st *m_event;
+    struct CUevent_st *m_event;
 };
 
-class CUevent_st {
+struct CUevent_st {
 public:
    CUevent_st( bool blocking )
    {


### PR DESCRIPTION
This fixes some errors and warnings reported by clang during compilation. Most of them are cleanups of class vs struct. I took clang's advice of if they should be a class or a struct (and it compiles with fewer warnings). There are a few other miscellaneous changes here, too.