### PR TITLE
Rework makefiles to allow selection of CC/CXX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ no_opencl_support:
 	@echo "Warning: gpgpu-sim is building without opencl support. Make sure NVOPENCL_LIBDIR and NVOPENCL_INCDIR are set"
 
 $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
-	g++ -shared -Wl,-soname,libcudart_$(GPGPUSIM_BUILD).so -Wl,--version-script=linux-so-version.txt\
+	$(CXX) $(LDFLAGS) -shared -Wl,-soname,libcudart_$(GPGPUSIM_BUILD).so -Wl,--version-script=linux-so-version.txt \
 			$(SIM_OBJ_FILES_DIR)/libcuda/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \
@@ -165,7 +165,7 @@ $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.9.1 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.9.1; fi
 
 $(SIM_LIB_DIR)/libcudart.dylib: makedirs $(LIBS) cudalib
-	g++ -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.1,-current_version,1.1\
+	$(CXX) -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.1,-current_version,1.1\
 			$(SIM_OBJ_FILES_DIR)/libcuda/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \
@@ -176,7 +176,7 @@ $(SIM_LIB_DIR)/libcudart.dylib: makedirs $(LIBS) cudalib
 			-o $(SIM_LIB_DIR)/libcudart.dylib
 
 $(SIM_LIB_DIR)/libOpenCL.so: makedirs $(LIBS) opencllib
-	g++ -shared -Wl,-soname,libOpenCL_$(GPGPUSIM_BUILD).so \
+	$(CXX) -shared -Wl,-soname,libOpenCL_$(GPGPUSIM_BUILD).so \
 			$(SIM_OBJ_FILES_DIR)/libopencl/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/*.o \
 			$(SIM_OBJ_FILES_DIR)/cuda-sim/decuda_pred_table/*.o \

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -3,9 +3,7 @@ LEXFLAGS	= -B
 YACC		= bison
 YFLAGS		= -t -d --report=all --verbose
 CCFLAGS		= -ggdb -fPIC -Wall -Wno-unused-function -Wno-sign-compare 
-CXX			= g++
 CXXFLAGS	= ${CCFLAGS}
-LD			= g++
 LDFLAGS		= ${CCFLAGS}
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)/cuobjdump_to_ptxplus
 

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -28,16 +28,16 @@ $(OUTPUT_DIR)/cuobjdump_to_ptxplus: $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/
 $(OUTPUT_DIR)/lex.ptx_.c : ../src/cuda-sim/ptx.l
 	${LEX} ${LEXFLAGS} -o$(OUTPUT_DIR)/lex.ptx_.c ../src/cuda-sim/ptx.l
 
-$(OUTPUT_DIR)/ptx.tab.c : ../src/cuda-sim/ptx.y
-	${YACC} ${YFLAGS} --name-prefix=ptx_ -v ../src/cuda-sim/ptx.y  --file-prefix=$(OUTPUT_DIR)/ptx
+$(OUTPUT_DIR)/ptx.tab.cpp : ../src/cuda-sim/ptx.ypp
+	${YACC} ${YFLAGS} --name-prefix=ptx_ -v ../src/cuda-sim/ptx.ypp  --file-prefix=$(OUTPUT_DIR)/ptx
 
-$(OUTPUT_DIR)/ptx.tab.h :$(OUTPUT_DIR)/ptx.tab.c
+$(OUTPUT_DIR)/ptx.tab.hpp : $(OUTPUT_DIR)/ptx.tab.cpp
 
-$(OUTPUT_DIR)/lex.ptx_.o : $(OUTPUT_DIR)/lex.ptx_.c $(OUTPUT_DIR)/ptx.tab.h
+$(OUTPUT_DIR)/lex.ptx_.o : $(OUTPUT_DIR)/lex.ptx_.c $(OUTPUT_DIR)/ptx.tab.hpp
 	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/lex.ptx_.c -o $@
 
-$(OUTPUT_DIR)/ptx.tab.o : $(OUTPUT_DIR)/ptx.tab.c ptx_parser.h
-	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/ptx.tab.c -o $@
+$(OUTPUT_DIR)/ptx.tab.o : $(OUTPUT_DIR)/ptx.tab.cpp ptx_parser.h
+	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/ptx.tab.cpp -o $@
 
 $(OUTPUT_DIR)/%_lexer.cc: %.l $(OUTPUT_DIR)/%_parser.hh
 	$(LEX) $(LEXFLAGS) -P $*_ -o$@ $<

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -21,7 +21,7 @@ MAKEFLAGS += --no-builtin-rules
 .SECONDARY:
 
 $(OUTPUT_DIR)/cuobjdump_to_ptxplus: $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/cuobjdumpInstList.o $(OUTPUT_DIR)/cuobjdump_to_ptxplus.o $(PTX_PARSER_OBJECTS) $(SASS_PARSER_OBJECTS) $(ELF_PARSER_OBJECTS) $(HEADER_PARSER_OBJECTS)
-	${LD} ${LDFLAGS} -o $@ $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/cuobjdumpInstList.o $(OUTPUT_DIR)/cuobjdump_to_ptxplus.o $(PTX_PARSER_OBJECTS) $(SASS_PARSER_OBJECTS) $(ELF_PARSER_OBJECTS) $(HEADER_PARSER_OBJECTS)
+	$(CXX) ${LDFLAGS} -o $@ $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/cuobjdumpInstList.o $(OUTPUT_DIR)/cuobjdump_to_ptxplus.o $(PTX_PARSER_OBJECTS) $(SASS_PARSER_OBJECTS) $(ELF_PARSER_OBJECTS) $(HEADER_PARSER_OBJECTS)
 
 
 $(OUTPUT_DIR)/lex.ptx_.c : ../src/cuda-sim/ptx.l

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -24,16 +24,16 @@ $(OUTPUT_DIR)/cuobjdump_to_ptxplus: $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/
 	$(CXX) ${LDFLAGS} -o $@ $(OUTPUT_DIR)/cuobjdumpInst.o $(OUTPUT_DIR)/cuobjdumpInstList.o $(OUTPUT_DIR)/cuobjdump_to_ptxplus.o $(PTX_PARSER_OBJECTS) $(SASS_PARSER_OBJECTS) $(ELF_PARSER_OBJECTS) $(HEADER_PARSER_OBJECTS)
 
 
-$(OUTPUT_DIR)/lex.ptx_.c : ../src/cuda-sim/ptx.l
-	${LEX} ${LEXFLAGS} -o$(OUTPUT_DIR)/lex.ptx_.c ../src/cuda-sim/ptx.l
+$(OUTPUT_DIR)/lex.ptx_.cc : ../src/cuda-sim/ptx.l
+	${LEX} ${LEXFLAGS} -o$(OUTPUT_DIR)/lex.ptx_.cc ../src/cuda-sim/ptx.l
 
 $(OUTPUT_DIR)/ptx.tab.cpp : ../src/cuda-sim/ptx.ypp
 	${YACC} ${YFLAGS} --name-prefix=ptx_ -v ../src/cuda-sim/ptx.ypp  --file-prefix=$(OUTPUT_DIR)/ptx
 
 $(OUTPUT_DIR)/ptx.tab.hpp : $(OUTPUT_DIR)/ptx.tab.cpp
 
-$(OUTPUT_DIR)/lex.ptx_.o : $(OUTPUT_DIR)/lex.ptx_.c $(OUTPUT_DIR)/ptx.tab.hpp
-	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/lex.ptx_.c -o $@
+$(OUTPUT_DIR)/lex.ptx_.o : $(OUTPUT_DIR)/lex.ptx_.cc $(OUTPUT_DIR)/ptx.tab.hpp
+	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/lex.ptx_.cc -o $@
 
 $(OUTPUT_DIR)/ptx.tab.o : $(OUTPUT_DIR)/ptx.tab.cpp ptx_parser.h
 	${CXX} ${CXXFLAGS} -c $(OUTPUT_DIR)/ptx.tab.cpp -o $@

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -4,7 +4,6 @@ YACC		= bison
 YFLAGS		= -t -d --report=all --verbose
 CCFLAGS		= -ggdb -fPIC -Wall -Wno-unused-function -Wno-sign-compare 
 CXXFLAGS	= ${CCFLAGS}
-LDFLAGS		= ${CCFLAGS}
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)/cuobjdump_to_ptxplus
 
 CXXFLAGS += -I $(OUTPUT_DIR) -I $(OUTPUT_DIR)/../cuda-sim/ -I . -I ../src/cuda-sim/

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -2,8 +2,8 @@ LEX			= flex
 LEXFLAGS	= -B 
 YACC		= bison
 YFLAGS		= -t -d --report=all --verbose
-CCFLAGS		= -ggdb -fPIC -Wall -Wno-unused-function -Wno-sign-compare 
-CXXFLAGS	= ${CCFLAGS}
+CCFLAGS		= -ggdb -fPIC 
+CXXFLAGS	+= ${CCFLAGS}
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)/cuobjdump_to_ptxplus
 
 CXXFLAGS += -I $(OUTPUT_DIR) -I $(OUTPUT_DIR)/../cuda-sim/ -I . -I ../src/cuda-sim/

--- a/cuobjdump_to_ptxplus/Makefile
+++ b/cuobjdump_to_ptxplus/Makefile
@@ -79,7 +79,7 @@ depend:
 	makedepend -f$(OUTPUT_DIR)/Makefile.makedepend $(SRCS) 2> /dev/null
 
 clean:
-	rm -f lex.ptx_.c ptx.tab.c ptx.tab.h ptx.output
+	rm -f lex.ptx_.cc ptx.tab.cc ptx.tab.hpp ptx.output
 	rm -f elf_lexer.cc  elf_parser.cc  elf_parser.hh elf_parser.output
 	rm -f sass_lexer.cc  sass_parser.cc  sass_parser.hh  sass_parser.output
 	rm -f header_lexer.cc  header_parser.cc  header_parser.hh  header_parser.output

--- a/libcuda/Makefile
+++ b/libcuda/Makefile
@@ -67,18 +67,18 @@ ifeq ($(OPENGL_SUPPORT),1)
 endif
 
 ifeq ($(GNUC_CPP0X), 1)
-    CXXFLAGS = -std=c++0x
+    CXXFLAGS += -std=c++0x
 endif
 
 
 CREATELIBRARY    =  1
 DEBUG ?= 0
 ifeq ($(DEBUG),1)
-	CXXFLAGS +=  -Wall -Wno-unused-function -Wno-sign-compare -g -fPIC $(GL)
-	CCFLAGS += -Wall -Wno-unused-function -Wno-sign-compare -ggdb -fPIC
+	CXXFLAGS +=   -g -fPIC $(GL)
+	CCFLAGS += -ggdb -fPIC
 else
-	CXXFLAGS += -O3 -g -Wall -Wno-unused-function -Wno-sign-compare -fPIC $(GL)
-	CCFLAGS += -Wall -Wno-unused-function -Wno-sign-compare -fPIC
+	CXXFLAGS += -O3 -g -fPIC $(GL)
+	CCFLAGS +=  -fPIC
 endif
 
 PROG     =cuda

--- a/libcuda/Makefile
+++ b/libcuda/Makefile
@@ -71,8 +71,6 @@ ifeq ($(GNUC_CPP0X), 1)
 endif
 
 
-CPP = g++ $(SNOW)
-CC = gcc $(SNOW)
 CREATELIBRARY    =  1
 DEBUG ?= 0
 ifeq ($(DEBUG),1)
@@ -108,7 +106,7 @@ lib$(PROG).a: $(OBJS)
 	ar rcs $(OUTPUT_DIR)/lib$(PROG).a $(OBJS)
 
 $(OUTPUT_DIR)/%.o: %.cc
-	$(CPP) $(CXXFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
+	$(CXX) $(CXXFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
 
 $(OUTPUT_DIR)/%.o: %.c
 	$(CC) $(CCFLAGS) -I./ -I$(OUTPUT_DIR) -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -2209,10 +2209,16 @@ int CUDARTAPI __cudaSynchronizeThreads(void**, void*)
 ////////
 
 extern int ptx_parse();
+
 extern int ptx__scan_string(const char*);
 extern FILE *ptx_in;
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int ptxinfo_parse();
+#ifdef __cplusplus
+}
+#endif
 extern int ptxinfo_debug;
 extern FILE *ptxinfo_in;
 

--- a/libcuda/cuobjdump.l
+++ b/libcuda/cuobjdump.l
@@ -143,7 +143,6 @@ newlines	{newline}+
 
 
 	/* Looking for the identifier (filename) then the header is done */
-	/* <endheader>[[:alnum:]_\./]+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME; */
 <endheader>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return IDENTIFIER;
 
 

--- a/libopencl/Makefile
+++ b/libopencl/Makefile
@@ -66,8 +66,6 @@ ifeq ($(OPENGL_SUPPORT),1)
 	GL = -DOPENGL_SUPPORT
 endif
 
-CPP = g++
-CC = gcc
 CREATELIBRARY    =  1
 DEBUG ?= 0
 CCFLAGS = -O3 -g -Wall -fPIC $(GL)
@@ -106,11 +104,11 @@ depend:
 
 $(OUTPUT_DIR)/nvopencl_wrapper: nvopencl_wrapper.cc
 	if [ ! -d bin ]; then mkdir bin; fi
-	g++ $(CCFLAGS) nvopencl_wrapper.cc -I./ -I$(NVOPENCL_INCDIR)/ -L $(NVOPENCL_LIBDIR) -lOpenCL  -o $(OUTPUT_DIR)/bin/nvopencl_wrapper
+	$(CXX) $(CCFLAGS) nvopencl_wrapper.cc -I./ -I$(NVOPENCL_INCDIR)/ -L $(NVOPENCL_LIBDIR) -lOpenCL  -o $(OUTPUT_DIR)/bin/nvopencl_wrapper
 	
 
 $(OUTPUT_DIR)/%.o: %.cc
-	$(CPP) $(CCFLAGS) -I./ -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
+	$(CXX) $(CCFLAGS) -I./ -I$(CUDA_INSTALL_PATH)/include  -c $< -o $@
 
 clean:
 	rm -f $(PROG)

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,6 @@ endif
 
 OPTFLAGS += -g3 -fPIC
 
-CPP = g++ $(SNOW)
 OEXT = o
 
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)
@@ -76,7 +75,7 @@ clean:
 	rm -f *.o core *~ *.a Makefile.makedepend Makefile.makedepend.bak
 
 $(OUTPUT_DIR)/%.$(OEXT): %.cc
-	$(CPP) $(OPTFLAGS) $(CXXFLAGS) -o $(OUTPUT_DIR)/$*.$(OEXT) -c $*.cc
+	$(CXX) $(OPTFLAGS) $(CXXFLAGS) -o $(OUTPUT_DIR)/$*.$(OEXT) -c $*.cc
 
 option_parser.$(OEXT): option_parser.h
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ TRACE?=1
 
 include ../version_detection.mk
 
-CXXFLAGS = -Wall -DDEBUG
+CXXFLAGS += -DDEBUG
 CXXFLAGS += -DCUDART_VERSION=$(CUDART_VERSION)
 
 ifeq ($(GNUC_CPP0X), 1)

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -80,8 +80,8 @@ libgpgpu_ptx_sim.a: $(OBJS)
 $(OUTPUT_DIR)/ptx.tab.o: $(OUTPUT_DIR)/ptx.tab.cpp
 	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptx.tab.cpp -o $(OUTPUT_DIR)/ptx.tab.o
 
-$(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/lex.ptx_.c 
-	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptx_.c -o $(OUTPUT_DIR)/lex.ptx_.o
+$(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/lex.ptx_.cc 
+	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptx_.cc -o $(OUTPUT_DIR)/lex.ptx_.o
 
 $(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptxinfo.tab.cpp
 	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptxinfo.tab.cpp -o $(OUTPUT_DIR)/ptxinfo.tab.o
@@ -95,15 +95,15 @@ $(OUTPUT_DIR)/ptx.tab.cpp: ptx.ypp
 $(OUTPUT_DIR)/ptxinfo.tab.cpp: ptxinfo.ypp
 	bison --name-prefix=ptxinfo_ -v -d ptxinfo.ypp --file-prefix=$(OUTPUT_DIR)/ptxinfo
 
-$(OUTPUT_DIR)/lex.ptx_.c: ptx.l
-	flex --outfile=$(OUTPUT_DIR)/lex.ptx_.c ptx.l 
+$(OUTPUT_DIR)/lex.ptx_.cc: ptx.l
+	flex --outfile=$(OUTPUT_DIR)/lex.ptx_.cc ptx.l 
 
 $(OUTPUT_DIR)/lex.ptxinfo_.c: ptxinfo.l
 	flex --outfile=$(OUTPUT_DIR)/lex.ptxinfo_.c ptxinfo.l 
 
 clean:
 	rm -f *~ *.o *.gcda *.gcno *.gcov libgpgpu_ptx_sim.a \
-		ptx.tab.hpp ptx.tab.cpp ptx.output lex.ptx_.c \
+		ptx.tab.hpp ptx.tab.cpp ptx.output lex.ptx_.cc \
 		ptxinfo.tab.hpp ptxinfo.tab.cpp ptxinfo.output lex.ptxinfo_.c \
 		instructions.h ptx_parser_decode.def directed_tests.log 
 	rm -f $(OUTPUT_DIR)/decuda_pred_table/*.o

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -32,7 +32,6 @@ INTEL=0
 DEBUG?=0
 TRACE?=0
 
-CPP = g++ $(SNOW)
 ifeq ($(INTEL),1)
 	CPP = icpc
 	CC = icc
@@ -79,16 +78,16 @@ libgpgpu_ptx_sim.a: $(OBJS)
 	ar rcs $(OUTPUT_DIR)/libgpgpu_ptx_sim.a $(OUTPUT_DIR)/ptx.tab.o $(OUTPUT_DIR)/lex.ptx_.o $(OUTPUT_DIR)/ptxinfo.tab.o $(OUTPUT_DIR)/lex.ptxinfo_.o $(OBJS)
 
 $(OUTPUT_DIR)/ptx.tab.o: $(OUTPUT_DIR)/ptx.tab.c
-	$(CPP) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptx.tab.c -o $(OUTPUT_DIR)/ptx.tab.o
+	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptx.tab.c -o $(OUTPUT_DIR)/ptx.tab.o
 
 $(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/lex.ptx_.c 
-	$(CPP) -c $(OPT) $(OUTPUT_DIR)/lex.ptx_.c -o $(OUTPUT_DIR)/lex.ptx_.o
+	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptx_.c -o $(OUTPUT_DIR)/lex.ptx_.o
 
 $(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptxinfo.tab.c
-	$(CPP) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptxinfo.tab.c -o $(OUTPUT_DIR)/ptxinfo.tab.o
+	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptxinfo.tab.c -o $(OUTPUT_DIR)/ptxinfo.tab.o
 
 $(OUTPUT_DIR)/lex.ptxinfo_.o: $(OUTPUT_DIR)/lex.ptxinfo_.c $(OUTPUT_DIR)/ptxinfo.tab.c
-	$(CPP) -c $(OPT) $(OUTPUT_DIR)/lex.ptxinfo_.c -o $(OUTPUT_DIR)/lex.ptxinfo_.o
+	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptxinfo_.c -o $(OUTPUT_DIR)/lex.ptxinfo_.o
 
 $(OUTPUT_DIR)/ptx.tab.c: ptx.y
 	bison --name-prefix=ptx_ -v -d ptx.y --file-prefix=$(OUTPUT_DIR)/ptx

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -33,7 +33,7 @@ DEBUG?=0
 TRACE?=0
 
 ifeq ($(INTEL),1)
-	CPP = icpc
+	CXX = icpc
 	CC = icc
 endif
 

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -77,23 +77,23 @@ depend:
 libgpgpu_ptx_sim.a: $(OBJS) 
 	ar rcs $(OUTPUT_DIR)/libgpgpu_ptx_sim.a $(OUTPUT_DIR)/ptx.tab.o $(OUTPUT_DIR)/lex.ptx_.o $(OUTPUT_DIR)/ptxinfo.tab.o $(OUTPUT_DIR)/lex.ptxinfo_.o $(OBJS)
 
-$(OUTPUT_DIR)/ptx.tab.o: $(OUTPUT_DIR)/ptx.tab.c
-	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptx.tab.c -o $(OUTPUT_DIR)/ptx.tab.o
+$(OUTPUT_DIR)/ptx.tab.o: $(OUTPUT_DIR)/ptx.tab.cpp
+	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptx.tab.cpp -o $(OUTPUT_DIR)/ptx.tab.o
 
 $(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/lex.ptx_.c 
 	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptx_.c -o $(OUTPUT_DIR)/lex.ptx_.o
 
-$(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptxinfo.tab.c
-	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptxinfo.tab.c -o $(OUTPUT_DIR)/ptxinfo.tab.o
+$(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptxinfo.tab.cpp
+	$(CXX) -c $(OPT) -DYYDEBUG $(OUTPUT_DIR)/ptxinfo.tab.cpp -o $(OUTPUT_DIR)/ptxinfo.tab.o
 
-$(OUTPUT_DIR)/lex.ptxinfo_.o: $(OUTPUT_DIR)/lex.ptxinfo_.c $(OUTPUT_DIR)/ptxinfo.tab.c
+$(OUTPUT_DIR)/lex.ptxinfo_.o: $(OUTPUT_DIR)/lex.ptxinfo_.c $(OUTPUT_DIR)/ptxinfo.tab.cpp
 	$(CXX) -c $(OPT) $(OUTPUT_DIR)/lex.ptxinfo_.c -o $(OUTPUT_DIR)/lex.ptxinfo_.o
 
-$(OUTPUT_DIR)/ptx.tab.c: ptx.y
-	bison --name-prefix=ptx_ -v -d ptx.y --file-prefix=$(OUTPUT_DIR)/ptx
+$(OUTPUT_DIR)/ptx.tab.cpp: ptx.ypp
+	bison --name-prefix=ptx_ -v -d ptx.ypp --file-prefix=$(OUTPUT_DIR)/ptx
 
-$(OUTPUT_DIR)/ptxinfo.tab.c: ptxinfo.y
-	bison --name-prefix=ptxinfo_ -v -d ptxinfo.y --file-prefix=$(OUTPUT_DIR)/ptxinfo
+$(OUTPUT_DIR)/ptxinfo.tab.cpp: ptxinfo.ypp
+	bison --name-prefix=ptxinfo_ -v -d ptxinfo.ypp --file-prefix=$(OUTPUT_DIR)/ptxinfo
 
 $(OUTPUT_DIR)/lex.ptx_.c: ptx.l
 	flex --outfile=$(OUTPUT_DIR)/lex.ptx_.c ptx.l 
@@ -103,16 +103,16 @@ $(OUTPUT_DIR)/lex.ptxinfo_.c: ptxinfo.l
 
 clean:
 	rm -f *~ *.o *.gcda *.gcno *.gcov libgpgpu_ptx_sim.a \
-		ptx.tab.h ptx.tab.c ptx.output lex.ptx_.c \
-		ptxinfo.tab.h ptxinfo.tab.c ptxinfo.output lex.ptxinfo_.c \
+		ptx.tab.hpp ptx.tab.cpp ptx.output lex.ptx_.c \
+		ptxinfo.tab.hpp ptxinfo.tab.cpp ptxinfo.output lex.ptxinfo_.c \
 		instructions.h ptx_parser_decode.def directed_tests.log 
 	rm -f $(OUTPUT_DIR)/decuda_pred_table/*.o
 	rm -f $(OUTPUT_DIR)/Makefile.makedepend $(OUTPUT_DIR)/Makefile.makedepend.bak
 
 $(OUTPUT_DIR)/%.o: %.c
-	$(CPP) -c $(OPT) $< -o $(OUTPUT_DIR)/$*.o
+	$(CXX) -c $(OPT) $< -o $(OUTPUT_DIR)/$*.o
 $(OUTPUT_DIR)/%.o: %.cc
-	$(CPP) -c $(CXX_OPT) $< -o $(OUTPUT_DIR)/$*.o
+	$(CXX) -c $(CXX_OPT) $< -o $(OUTPUT_DIR)/$*.o
 
 $(OUTPUT_DIR)/instructions.h: instructions.cc
 	@touch $*.h
@@ -126,24 +126,24 @@ $(OUTPUT_DIR)/instructions.h: instructions.cc
 	@chmod -w $*.h
 	@echo "created $(OUTPUT_DIR)/instructions.h"
 
-$(OUTPUT_DIR)/ptx_parser_decode.def: $(OUTPUT_DIR)/ptx.tab.c
+$(OUTPUT_DIR)/ptx_parser_decode.def: $(OUTPUT_DIR)/ptx.tab.cpp
 ifeq ($(shell uname),Linux)
-	cat $(OUTPUT_DIR)/ptx.tab.h | grep "=" | sed 's/^[ ]\+//' | sed 's/[=,]//g' | sed 's/\([_A-Z1-9]\+\)[ ]\+\([0-9]\+\)/\1 \1/' | sed 's/^/DEF(/' | sed 's/ /,"/' | sed 's/$$/")/' > $(OUTPUT_DIR)/ptx_parser_decode.def
+	cat $(OUTPUT_DIR)/ptx.tab.hpp | grep "=" | sed 's/^[ ]\+//' | sed 's/[=,]//g' | sed 's/\([_A-Z1-9]\+\)[ ]\+\([0-9]\+\)/\1 \1/' | sed 's/^/DEF(/' | sed 's/ /,"/' | sed 's/$$/")/' > $(OUTPUT_DIR)/ptx_parser_decode.def
 else
-	cat $(OUTPUT_DIR)/ptx.tab.h | grep "=" | sed -E 's/^ +//' | sed 's/[=,]//g' | sed -E 's/([_A-Z1-9]+).*/\1 \1/' | sed 's/^/DEF(/' | sed 's/ /,"/' | sed 's/$$/")/' > $(OUTPUT_DIR)/ptx_parser_decode.def
+	cat $(OUTPUT_DIR)/ptx.tab.hpp | grep "=" | sed -E 's/^ +//' | sed 's/[=,]//g' | sed -E 's/([_A-Z1-9]+).*/\1 \1/' | sed 's/^/DEF(/' | sed 's/ /,"/' | sed 's/$$/")/' > $(OUTPUT_DIR)/ptx_parser_decode.def
 endif
 
-$(OUTPUT_DIR)/instructions.o: $(OUTPUT_DIR)/instructions.h $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/cuda_device_printf.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/ptx_ir.o: $(OUTPUT_DIR)/ptx.tab.c $(OUTPUT_DIR)/ptx_parser_decode.def
-$(OUTPUT_DIR)/ptx_loader.o: $(OUTPUT_DIR)/ptx.tab.c $(OUTPUT_DIR)/ptx_parser_decode.def
-$(OUTPUT_DIR)/ptx_parser.o: $(OUTPUT_DIR)/ptx.tab.c $(OUTPUT_DIR)/ptx_parser_decode.def
-$(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/ptx-stats.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/ptx_sim.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/cuda-sim.o: $(OUTPUT_DIR)/ptx.tab.c $(SIM_OBJ_FILES_DIR)/detailed_version
-$(OUTPUT_DIR)/lex.ptxinfo_.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/ptx.tab.c
-$(OUTPUT_DIR)/cuda_device_runtime.o: $(OUTPUT_DIR)/ptx.tab.c
+$(OUTPUT_DIR)/instructions.o: $(OUTPUT_DIR)/instructions.h $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/cuda_device_printf.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/ptx_ir.o: $(OUTPUT_DIR)/ptx.tab.cpp $(OUTPUT_DIR)/ptx_parser_decode.def
+$(OUTPUT_DIR)/ptx_loader.o: $(OUTPUT_DIR)/ptx.tab.cpp $(OUTPUT_DIR)/ptx_parser_decode.def
+$(OUTPUT_DIR)/ptx_parser.o: $(OUTPUT_DIR)/ptx.tab.cpp $(OUTPUT_DIR)/ptx_parser_decode.def
+$(OUTPUT_DIR)/ptxinfo.tab.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/ptx-stats.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/ptx_sim.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/cuda-sim.o: $(OUTPUT_DIR)/ptx.tab.cpp $(SIM_OBJ_FILES_DIR)/detailed_version
+$(OUTPUT_DIR)/lex.ptxinfo_.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/lex.ptx_.o: $(OUTPUT_DIR)/ptx.tab.cpp
+$(OUTPUT_DIR)/cuda_device_runtime.o: $(OUTPUT_DIR)/ptx.tab.cpp
 
 include $(OUTPUT_DIR)/Makefile.makedepend

--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -66,6 +66,7 @@
 
 #ifndef CUDA_MATH
 #define CUDA_MATH
+#include <cmath>
 
 // cuda math implementations
 #undef max

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -30,7 +30,7 @@
 
 #include "instructions.h"
 #include "ptx_ir.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include "ptx_sim.h"
 #include <stdio.h>
 

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -30,7 +30,7 @@
 #include "ptx_ir.h"
 #include "opcodes.h"
 #include "ptx_sim.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include <stdlib.h>
 #include <math.h>
 #include <fenv.h>

--- a/src/cuda-sim/ptx.l
+++ b/src/cuda-sim/ptx.l
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %option prefix="ptx_"
 %{
 #include "opcodes.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include <string.h>
 
 char linebuf[1024];

--- a/src/cuda-sim/ptx.ypp
+++ b/src/cuda-sim/ptx.ypp
@@ -207,10 +207,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	#include <stdlib.h>
 	#include <string.h>
 	#include <math.h>
-	void syntax_not_implemented();
 	extern int g_func_decl;
+#ifdef __cplusplus
+extern "C" {
+#endif
+	void syntax_not_implemented();
 	int ptx_lex(void);
 	int ptx_error(const char *);
+#ifdef __cplusplus
+}
+#endif
 %}
 
 %%

--- a/src/cuda-sim/ptx.ypp
+++ b/src/cuda-sim/ptx.ypp
@@ -208,15 +208,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	#include <string.h>
 	#include <math.h>
 	extern int g_func_decl;
-#ifdef __cplusplus
-extern "C" {
-#endif
 	void syntax_not_implemented();
 	int ptx_lex(void);
 	int ptx_error(const char *);
-#ifdef __cplusplus
-}
-#endif
 %}
 
 %%

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -28,7 +28,7 @@
 
 #include "ptx_parser.h"
 #include "ptx_ir.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include "opcodes.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -44,8 +44,13 @@ bool g_override_embedded_ptx = false;
 /// extern prototypes
 
 extern int ptx_parse();
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int ptx__scan_string(const char*);
-
+#ifdef __cplusplus
+}
+#endif
 extern std::map<unsigned,const char*> get_duplicate();
 
 const char *g_ptxinfo_filename;

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -44,13 +44,7 @@ bool g_override_embedded_ptx = false;
 /// extern prototypes
 
 extern int ptx_parse();
-#ifdef __cplusplus
-extern "C" {
-#endif
 extern int ptx__scan_string(const char*);
-#ifdef __cplusplus
-}
-#endif
 extern std::map<unsigned,const char*> get_duplicate();
 
 const char *g_ptxinfo_filename;

--- a/src/cuda-sim/ptx_parser.cc
+++ b/src/cuda-sim/ptx_parser.cc
@@ -27,7 +27,7 @@
 
 #include "ptx_parser.h"
 #include "ptx_ir.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include <stdarg.h>
 
 extern int ptx_error( const char *s );

--- a/src/cuda-sim/ptx_sim.cc
+++ b/src/cuda-sim/ptx_sim.cc
@@ -28,7 +28,7 @@
 #include "ptx_sim.h"
 #include <string>
 #include "ptx_ir.h"
-#include "ptx.tab.h"
+#include "ptx.tab.hpp"
 #include "../gpgpu-sim/gpu-sim.h"
 #include "../gpgpu-sim/shader.h"
 

--- a/src/cuda-sim/ptxinfo.l
+++ b/src/cuda-sim/ptxinfo.l
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %option yylineno
 %option prefix="ptxinfo_"
 %{
-#include "ptxinfo.tab.h"
+#include "ptxinfo.tab.hpp"
 #include <string.h>
 
 #define LINEBUF_SIZE 1024

--- a/src/cuda-sim/ptxinfo.ypp
+++ b/src/cuda-sim/ptxinfo.ypp
@@ -66,7 +66,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	
 	static unsigned g_declared;
 	static unsigned g_system;
+#ifdef __cplusplus
+extern "C" {
+#endif
 	int ptxinfo_lex(void);
+#ifdef __cplusplus
+}
+#endif
 	void ptxinfo_addinfo();
 	void ptxinfo_function(const char *fname );
 	void ptxinfo_regs( unsigned nregs );

--- a/src/gpgpu-sim/Makefile
+++ b/src/gpgpu-sim/Makefile
@@ -32,9 +32,7 @@ DEBUG?=0
 TRACE?=0
 
 ifeq ($(DEBUG),1)
-	CXXFLAGS = -Wall -DDEBUG
-else
-	CXXFLAGS = -Wall
+	CXXFLAGS += -DDEBUG
 endif
 
 ifeq ($(TRACE),1)

--- a/src/gpgpu-sim/Makefile
+++ b/src/gpgpu-sim/Makefile
@@ -61,7 +61,6 @@ endif
 OPTFLAGS += -g3 -fPIC
 OPTFLAGS += -DCUDART_VERSION=$(CUDART_VERSION)
 
-CPP = g++ $(SNOW)
 OEXT = o
 
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)/gpgpu-sim
@@ -88,7 +87,7 @@ depend:
 	makedepend -f$(OUTPUT_DIR)/Makefile.makedepend -p$(OUTPUT_DIR)/ $(CSRCS) 2> /dev/null
 
 $(OUTPUT_DIR)/%.$(OEXT): %.cc
-	$(CPP) $(OPTFLAGS) $(CXXFLAGS) $(POWER_FLAGS) -o $(OUTPUT_DIR)/$*.$(OEXT) -c $*.cc
+	$(CXX) $(OPTFLAGS) $(CXXFLAGS) $(POWER_FLAGS) -o $(OUTPUT_DIR)/$*.$(OEXT) -c $*.cc
 
 clean:
 	rm -f *.o core *~ *.a 

--- a/src/gpgpu-sim/Makefile
+++ b/src/gpgpu-sim/Makefile
@@ -95,10 +95,10 @@ clean:
 
 $(OUTPUT_DIR)/option_parser.$(OEXT): option_parser.h
 
-$(OUTPUT_DIR)/dram_sched.$(OEXT): $(OUTPUT_DIR)/../cuda-sim/ptx.tab.h
+$(OUTPUT_DIR)/dram_sched.$(OEXT): $(OUTPUT_DIR)/../cuda-sim/ptx.tab.hpp
 
-$(OUTPUT_DIR)/../cuda-sim/ptx.tab.h:
-	make -C ../cuda-sim/ $(OUTPUT_DIR)/../cuda-sim/ptx.tab.c
+$(OUTPUT_DIR)/../cuda-sim/ptx.tab.hpp:
+	make -C ../cuda-sim/ $(OUTPUT_DIR)/../cuda-sim/ptx.tab.cpp
 
 include $(OUTPUT_DIR)/Makefile.makedepend
 

--- a/src/gpuwattch/cacti/cacti.mk
+++ b/src/gpuwattch/cacti/cacti.mk
@@ -9,7 +9,6 @@ ifndef NTHREADS
   NTHREADS = 8
 endif
 
-
 LIBS = 
 INCS = -lm
 
@@ -18,20 +17,11 @@ ifeq ($(TAG),dbg)
   OPT = -ggdb -g -O0 -DNTHREADS=1  -gstabs+
 else
   DBG = 
-  OPT = -O3 -msse2 -mfpmath=sse -DNTHREADS=$(NTHREADS)
+  OPT = -O3  -DNTHREADS=$(NTHREADS)
 endif
-
+LDFLAGS += -lc++
 #CXXFLAGS = -Wall -Wno-unknown-pragmas -Winline $(DBG) $(OPT) 
-CXXFLAGS = -Wno-unknown-pragmas $(DBG) $(OPT) 
-
-ifeq ($(shell getconf LONG_BIT),64) 
-	CXX = g++ -m64
-	CC  = gcc -m64
-else 
-	CXX = g++ -m32
-	CC  = gcc -m32
-endif 
-
+CXXFLAGS += -Wno-unknown-pragmas $(DBG) $(OPT) 
 
 SRCS  = area.cc bank.cc mat.cc main.cc Ucache.cc io.cc technology.cc basic_circuit.cc parameter.cc \
 		decoder.cc component.cc uca.cc subarray.cc wire.cc htree2.cc \
@@ -45,7 +35,7 @@ INCLUDES       = -I /usr/include/python2.4 -I /usr/lib/python2.4/config
 all: $(OUTPUT_DIR)/$(TARGET)
 
 $(OUTPUT_DIR)/$(TARGET) : $(OBJS)
-	$(CXX) $(OBJS) -o $@ $(INCS) $(CXXFLAGS) $(LIBS) -pthread
+	$(CXX) $(OBJS) -o $@ $(INCS) $(LDFLAGS) $(LIBS) -pthread
 
 #obj_$(TAG)/%.o : %.cc
 #	$(CXX) -c $(CXXFLAGS) $(INCS) -o $@ $<

--- a/src/gpuwattch/mcpat.mk
+++ b/src/gpuwattch/mcpat.mk
@@ -10,34 +10,20 @@ ifndef NTHREADS
 endif
 
 
-LIBS = -I/usr/lib/ -I/usr/lib64/
-INCS = -lm
-
-CC=
-CXX=
-
-ifeq ($(shell getconf LONG_BIT),64) 
-	CXX = g++ -m64
-	CC  = gcc -m64
-else 
-	CXX = g++ -m32
-	CC  = gcc -m32
-endif 
+INCS = -I/usr/lib/ -I/usr/lib64/
+LIBS = -lm -lz
 
 ifeq ($(TAG),dbg)
   DBG = -Wall 
-  OPT = -ggdb -fPIC -g -O0 -DNTHREADS=1 -Icacti -lz
+  OPT = -ggdb -fPIC -g -O0 -DNTHREADS=1 -Icacti
 else
   DBG = 
-  OPT = -O3 -fPIC -msse2 -mfpmath=sse -DNTHREADS=$(NTHREADS) -Icacti -lz
+  OPT = -O3 -fPIC -DNTHREADS=$(NTHREADS) -Icacti
   #OPT = -O0 -DNTHREADS=$(NTHREADS)
 endif
 
 #CXXFLAGS = -Wall -Wno-unknown-pragmas -Winline $(DBG) $(OPT) 
-CXXFLAGS = -Wno-unknown-pragmas $(DBG) $(OPT) 
-
-
-
+CXXFLAGS += -Wno-unknown-pragmas $(DBG) $(OPT) 
 
 VPATH = cacti
 
@@ -83,13 +69,13 @@ OBJS = $(patsubst %.cc,$(OUTPUT_DIR)/%.o,$(SRCS))
 all: $(OUTPUT_DIR)/$(TARGET)
 
 $(OUTPUT_DIR)/$(TARGET) : $(OBJS)
-	$(CXX) $(OBJS) -o $@ $(INCS) $(CXXFLAGS) $(LIBS) -pthread
+	$(CXX) $(LDFLAGS) $(OBJS) -o $@ $(LIBS) -pthread
 
 #obj_$(TAG)/%.o : %.cc
 #	$(CXX) -c $(CXXFLAGS) $(INCS) -o $@ $<
 
 $(OUTPUT_DIR)/%.o : %.cc
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(INCS) -c $< -o $@
 
 $(OUTPUT_DIR)/Makefile.makedepend: depend
 

--- a/src/intersim2/Makefile
+++ b/src/intersim2/Makefile
@@ -27,8 +27,6 @@
 #
 # Makefile
 #
-CXX = g++
-CC = gcc
 CREATE_LIBRARY ?= 0
 INTERFACE = interconnect_interface.cpp
 DEBUG ?= 0

--- a/src/intersim2/Makefile
+++ b/src/intersim2/Makefile
@@ -42,12 +42,12 @@ ifeq ($(CREATE_LIBRARY),1)
 INCPATH += -I$(GPGPUSIM_ROOT)/src/gpgpu-sim/
 endif
 
-CPPFLAGS += -Wall $(INCPATH) $(DEFINE)
+CXXFLAGS += -Wall $(INCPATH) $(DEFINE)
 ifneq ($(DEBUG),1)
-CPPFLAGS += -O3
+CXXFLAGS += -O3
 endif
-CPPFLAGS += -g
-CPPFLAGS += -fPIC
+CXXFLAGS += -g
+CXXFLAGS += -fPIC
 LFLAGS +=
 
 
@@ -135,33 +135,33 @@ depend:
 	makedepend -f$(OBJDIR)/Makefile.makedepend -I$(INCPATH) -p$(OBJDIR)/ $(ALL_SRCS) 2> /dev/null
 
 ${LEX_OBJS}: $(OBJDIR)/lex.yy.c $(OBJDIR)/y.tab.h
-	$(CC) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CXXFLAGS) -c $< -o $@
 
 ${YACC_OBJS}: $(OBJDIR)/y.tab.c $(OBJDIR)/y.tab.h
-	$(CC) $(CPPFLAGS) -c $< -o $@
+	$(CC) $(CXXFLAGS) -c $< -o $@
 
 ${OBJDIR}/%.o: %.cpp 
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # rules to compile networks
 ${OBJDIR}/%.o: networks/%.cpp 
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # rules to compile arbiters
 ${OBJDIR}/%.o: arbiters/%.cpp 
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # rules to compile allocators
 ${OBJDIR}/%.o: allocators/%.cpp 
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # rules to compile routers
 ${OBJDIR}/%.o: routers/%.cpp 
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 # rules to compile power classes
 ${OBJDIR}/%.o: power/%.cpp
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(OBJS) 


### PR DESCRIPTION
This patchset reworks the Makefiles to use the CXX environment variable as the compiler, instead of blindly using g++ (which may not be the proper version, etc...).

It also changes to compiling the generated compiler/parser using C++. The generated code includes C++ header files, and warnings were being generated due to including C++ files from C.

In addition, this code should now compile on the PowerPC platform using clang. 