### PR TITLE
Dev override ptxplus

### DIFF
--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -99,7 +99,7 @@ void print_ptx_file( const char *p, unsigned source_num, const char *filename )
    fflush(stdout);
 }
 
-char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilename, const std::string elffilename, const std::string sassfilename)
+std::string gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilename, const std::string elffilename, const std::string sassfilename)
 {
 
 	printf("GPGPU-Sim PTX: converting EMBEDDED .ptx file to ptxplus \n");
@@ -131,8 +131,6 @@ char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilenam
 	}
 	fileStream.close();
 
-	char* ptxplus_str = new char [strlen(text.c_str())+1];
-	strcpy(ptxplus_str, text.c_str());
 
 	if (!m_ptx_save_converted_ptxplus){
 		char rm_commandline[1024];
@@ -148,7 +146,7 @@ char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptxfilenam
 	}
 	printf("GPGPU-Sim PTX: DONE converting EMBEDDED .ptx file to ptxplus \n");
 
-	return ptxplus_str;
+	return text;
 }
 
 

--- a/src/cuda-sim/ptx_loader.h
+++ b/src/cuda-sim/ptx_loader.h
@@ -33,7 +33,7 @@ extern bool g_override_embedded_ptx;
  
 class symbol_table *gpgpu_ptx_sim_load_ptx_from_string( const char *p, unsigned source_num );
 void gpgpu_ptxinfo_load_from_string( const char *p_for_info, unsigned source_num, unsigned sm_version=20 );
-char* gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
+std::string gpgpu_ptx_sim_convert_ptx_and_sass_to_ptxplus(const std::string ptx_str, const std::string sass_str, const std::string elf_str);
 bool keep_intermediate_files();
 
 #endif


### PR DESCRIPTION
This adds a new environment variable, PTXPLUS_SIM_KERNELFILE , which can be used to override the PTXPLUS file used in the simulation. This is useful, for example, when doing register reallocation. Currently the code still uses the ptxinfo from the original PTX output to determine the number of registers, etc, that are needed. It doesn't seem like there are any functions to determine the register count from the ptxplus (and ptxas can't read ptxplus).

This fixes some bugs with respect to using "delete" to free memory which was malloced. It also fixes some memory leaks of PTX.



