### PR TITLE
Getting the simulator to compile with older versions of g++

### DIFF
--- a/src/cuda-sim/cuda-math.h
+++ b/src/cuda-sim/cuda-math.h
@@ -67,6 +67,8 @@
 #ifndef CUDA_MATH
 #define CUDA_MATH
 
+#include <cmath>
+
 // cuda math implementations
 #undef max
 #undef min
@@ -147,6 +149,7 @@ float __ll2float_rd(long long int a) {
 // implementing int to float intrinsics with different rounding modes 
 #include <device_types.h>
 #include <fenv.h>
+
 
 // 32-bit integer to float
 float __int2float_rn(int a) {


### PR DESCRIPTION
Without this Redhat 6 default gcc will not compile.