### PR TITLE
libcuda: removed comment from cuobjdump.l

### DIFF
--- a/libcuda/cuobjdump.l
+++ b/libcuda/cuobjdump.l
@@ -143,7 +143,6 @@ newlines	{newline}+
 
 
 	/* Looking for the identifier (filename) then the header is done */
-	/* <endheader>[[:alnum:]_\./]+	yylval.string_value = strdup(yytext); yy_pop_state(); return FILENAME; */
 <endheader>{notnewline}+	yylval.string_value = strdup(yytext); yy_pop_state(); return IDENTIFIER;
 
 


### PR DESCRIPTION
This comment made the build fail in ubuntu 18.04 due to a flex error. This error is probably produced by a flex bug.