### PR TITLE
Fix spelling from adpative -> adaptive for volta cache config

### DIFF
--- a/configs/tested-cfgs/SM7_TITANV/gpgpusim.config
+++ b/configs/tested-cfgs/SM7_TITANV/gpgpusim.config
@@ -75,7 +75,7 @@
 # if the assigned shd mem = 0, then L1 cache = 128KB
 # For more info, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x 
 # disable this mode in case of multi kernels/apps execution
--adpative_volta_cache_config 1
+-adaptive_volta_cache_config 1
 # Volta unified cache has four ports
 -mem_unit_ports 4
 -gpgpu_cache:dl1  S:4:128:64,L:L:s:N:L,A:256:8,16:0,32

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -315,8 +315,8 @@ void shader_core_config::reg_options(class OptionParser * opp)
     option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_size,
                  "Size of shared memory per shader core (default 16kB)",
                  "16384");
-    option_parser_register(opp, "-adpative_volta_cache_config", OPT_BOOL, &adpative_volta_cache_config,
-                 "adpative_volta_cache_config",
+    option_parser_register(opp, "-adaptive_volta_cache_config", OPT_BOOL, &adaptive_volta_cache_config,
+                 "adaptive_volta_cache_config",
                  "0");
     option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_sizeDefault,
                  "Size of shared memory per shader core (default 16kB)",

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2949,7 +2949,7 @@ unsigned int shader_core_config::max_cta( const kernel_info_t &k ) const
        abort();
     }
 
-    if(adpative_volta_cache_config && !k.volta_cache_config_set) {
+    if(adaptive_volta_cache_config && !k.volta_cache_config_set) {
     	//For Volta, we assign the remaining shared memory to L1 cache
     	//For more info, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared-memory-7-x
     	unsigned total_shmed = kernel_info->smem * result;

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1523,7 +1523,7 @@ struct shader_core_config : public core_config
     //Jin: concurrent kernel on sm
     bool gpgpu_concurrent_kernel_sm;
 
-    bool adpative_volta_cache_config;
+    bool adaptive_volta_cache_config;
 };
 
 struct shader_core_stats_pod {


### PR DESCRIPTION
Change spelling of "-adpative_volta_cache_config" parameter and subsequent uses to "-adaptive_volta_cache_config".