### PR TITLE
Instruction added to enable support for cuDNN with cuda-9.0

### DIFF
--- a/src/cuda-sim/ptx.l
+++ b/src/cuda-sim/ptx.l
@@ -61,6 +61,7 @@ addc    TC; ptx_lval.int_value = ADDC_OP; return OPCODE;
 and	TC; ptx_lval.int_value = AND_OP; return OPCODE;
 andn	TC; ptx_lval.int_value = ANDN_OP; return OPCODE;
 atom	TC; ptx_lval.int_value = ATOM_OP; return OPCODE;
+bar.warp 	TC; ptx_lval.int_value = NOP_OP; return OPCODE;
 bar 	TC; ptx_lval.int_value = BAR_OP; return OPCODE;
 bfe     TC; ptx_lval.int_value = BFE_OP; return OPCODE;
 bfi     TC; ptx_lval.int_value = BFI_OP; return OPCODE;


### PR DESCRIPTION
Added instruction "bar.warp.sync". This instruction is parsed as NOP which is ok for stack-based reconvergence. This instruction is used in cuDNN with Cuda-9.0