### PR TITLE
Fix indentation bug of AerialVision

### DIFF
--- a/aerialvision/organizedata.py
+++ b/aerialvision/organizedata.py
@@ -97,7 +97,7 @@ def organizedata(fileVars):
         'sparse':OrganizeSparse,        # Vector data with 2D index  (used by DRAM access stats)
         'custom':0
     }
-       data_type_char = {int:'I', float:'f'}
+    data_type_char = {int:'I', float:'f'}
 
     print "Organizing data into internal format..."
 


### PR DESCRIPTION
I've found and fixed a minor bug when I running AerialVision.

```
Traceback (most recent call last):
  File "./aerialvision.py", line 79, in <module>
    import startup
  File "/home/redcarrottt/gpgpu-sim_distribution/aerialvision/startup.py", line 68, in <module>
    import guiclasses
  File "/home/redcarrottt/gpgpu-sim_distribution/aerialvision/guiclasses.py", line 81, in <module>
    import organizedata
  File "/home/redcarrottt/gpgpu-sim_distribution/aerialvision/organizedata.py", line 100
    data_type_char = {int:'I', float:'f'}
    ^
IndentationError: unexpected indent
```