### PR TITLE
Add support for multiple libraries to extract PTX files

### DIFF
--- a/README
+++ b/README
@@ -311,6 +311,11 @@ distributed separately on github under the repo ispass2009-benchmarks.
 The README.ISPASS-2009 file distributed with the benchmarks now contains 
 updated instructions for running the benchmarks on GPGPU-Sim v3.x.
 
+If you want to use the simulator to run cuDNN program, you should set following
+PYTORCH_BIN environment variable. If you want to use kernels embedded in multiple
+libraries, you can write the libraries' path separated by colons(:).
+
+export PYTORCH_BIN=/usr/local/cuda/lib64/libcudnn.so:/usr/local/cuda/lib64/libcublas.so
 
 3.  (OPTIONAL) Updating GPGPU-Sim (ADVANCED USERS ONLY)
 


### PR DESCRIPTION
In order to resolve Issue #112, I modified GPGPU-Sim so that it extracts PTX files from multiple libraries.

Existing GPGPU-Sim cannot run both convolution layer and FC layer since each layer requires ```libcudnn``` or ```libcublas```. Therefore, in Issue #112, it results in ```PTX not implementation error``` when simulating libcublas call.

After applying this patch, ```mnistCUDNN``` in https://github.com/gpgpu-sim/gpgpu-sim_simulations works well with Titan V config(Volta architecture).

You can the path of multiple libraries as following:
(each library path is separated by colons(:).)
```
export PYTORCH_BIN=/usr/local/cuda/lib64/libcudnn.so:/usr/local/cuda/lib64/libcublas.so
```