### PR TITLE
Fix SM6_TITANX config to use pascal file

### DIFF
--- a/configs/tested-cfgs/SM6_TITANX/gpgpusim.config
+++ b/configs/tested-cfgs/SM6_TITANX/gpgpusim.config
@@ -135,7 +135,7 @@
 
 # interconnection
 -network_mode 1 
--inter_config_file config_fermi_islip.icnt
+-inter_config_file config_pascal_islip.icnt
 
 # memory partition latency config 
 -rop_latency 120


### PR DESCRIPTION
SM6_TITANX config was using the SM2_GTX480 fermi icnt file. Changed it to the pascal file.