### PR TITLE
added temp. solution to bypass function pointers

### DIFF
--- a/src/cuda-sim/ptx.y
+++ b/src/cuda-sim/ptx.y
@@ -287,6 +287,7 @@ ptr_align_spec: ALIGN_DIRECTIVE INT_OPERAND
 statement_block: LEFT_BRACE statement_list RIGHT_BRACE 
 
 statement_list: directive_statement { add_directive(); }
+	| statement_list prototype_block {printf("Prototype statement detected. WARNING: this is not supported yet on GPGPU-SIM\n"); }
 	| instruction_statement { add_instruction(); }
 	| statement_list directive_statement { add_directive(); }
 	| statement_list instruction_statement { add_instruction(); }
@@ -402,6 +403,23 @@ initializer_list: LEFT_BRACE literal_list RIGHT_BRACE { add_array_initializer();
 
 literal_list: literal_operand
 	| literal_list COMMA literal_operand;
+
+// TODO: This is currently hardcoded to handle and ignore one specific case
+// that all prototype statements follow in the PTX from Pytorch. As a
+// workaround, this parses and ignores both the prototype declaration 
+// and calling of the prototype (which conveniently comes right after the 
+// declaration for all cases.) This should be changed to handle both 
+// declaring the prototype, and actually calling it.
+prototype_block: prototype_decl prototype_call
+
+prototype_decl: IDENTIFIER COLON CALLPROTOTYPE_DIRECTIVE LEFT_PAREN prototype_param RIGHT_PAREN IDENTIFIER LEFT_PAREN prototype_param RIGHT_PAREN SEMI_COLON 
+	      
+prototype_call: OPCODE LEFT_PAREN IDENTIFIER RIGHT_PAREN COMMA operand COMMA LEFT_PAREN IDENTIFIER RIGHT_PAREN COMMA IDENTIFIER SEMI_COLON
+	      | OPCODE IDENTIFIER COMMA LEFT_PAREN IDENTIFIER RIGHT_PAREN COMMA IDENTIFIER SEMI_COLON
+
+prototype_param: /* empty */
+	       | PARAM_DIRECTIVE B64_TYPE IDENTIFIER
+	       | PARAM_DIRECTIVE B32_TYPE IDENTIFIER
 
 instruction_statement:  instruction SEMI_COLON
 	| IDENTIFIER COLON { add_label($1); }    


### PR DESCRIPTION
Changes have been made to the parser in order to recognize function pointers and ignore them for now. This is required for pytorch to run on gpgpu-sim.