### PR TITLE
take account of shfl latency

### DIFF
--- a/configs/tested-cfgs/SM2_GTX480/gpgpusim.config
+++ b/configs/tested-cfgs/SM2_GTX480/gpgpusim.config
@@ -46,9 +46,9 @@
 -gpgpu_num_dp_units 0
 
 # Instruction latencies and initiation intervals
-# "ADD,MAX,MUL,MAD,DIV"
--ptx_opcode_latency_int 4,13,4,5,145
--ptx_opcode_initiation_int 1,2,2,1,8
+# "ADD,MAX,MUL,MAD,DIV,SHFL"
+-ptx_opcode_latency_int 4,13,4,5,145,32
+-ptx_opcode_initiation_int 1,2,2,1,8,4
 -ptx_opcode_latency_fp 4,13,4,5,39
 -ptx_opcode_initiation_fp 1,2,1,1,4
 -ptx_opcode_latency_dp 8,19,8,8,330

--- a/configs/tested-cfgs/SM6_TITANX/gpgpusim.config
+++ b/configs/tested-cfgs/SM6_TITANX/gpgpusim.config
@@ -56,11 +56,11 @@
 
 
 # Instruction latencies and initiation intervals
-# "ADD,MAX,MUL,MAD,DIV"
+# "ADD,MAX,MUL,MAD,DIV,SHFL"
 # All Div operations are executed on SFU unit
 # Throughput (initiation latency) are adopted from CUDA SDK document V8, section 5.4.1, Table 2
--ptx_opcode_latency_int 4,13,4,5,145
--ptx_opcode_initiation_int 1,1,1,1,4
+-ptx_opcode_latency_int 4,13,4,5,145,32
+-ptx_opcode_initiation_int 1,1,1,1,4,4
 -ptx_opcode_latency_fp 4,13,4,5,39
 -ptx_opcode_initiation_fp 1,2,1,1,4
 -ptx_opcode_latency_dp 8,19,8,8,330

--- a/configs/tested-cfgs/SM7_TITANV/gpgpusim.config
+++ b/configs/tested-cfgs/SM7_TITANV/gpgpusim.config
@@ -66,10 +66,10 @@
 # Instruction latencies and initiation intervals
 # "ADD,MAX,MUL,MAD,DIV"
 # All Div operations are executed on SFU unit
-# Throughput (initiation latency) are adopted from 
+# Throughput (initiation latency except shfl) are adopted from 
 # http://on-demand.gputechconf.com/gtc/2018/presentation/s8122-dissecting-the-volta-gpu-architecture-through-microbenchmarking.pdf
--ptx_opcode_latency_int 4,13,4,5,145
--ptx_opcode_initiation_int 2,2,2,2,8
+-ptx_opcode_latency_int 4,13,4,5,145,32
+-ptx_opcode_initiation_int 2,2,2,2,8,4
 -ptx_opcode_latency_fp 4,13,4,5,39
 -ptx_opcode_initiation_fp 2,2,2,2,4
 -ptx_opcode_latency_dp 8,19,8,8,330

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -71,9 +71,9 @@ unsigned cdp_latency[5];
 
 void ptx_opcocde_latency_options (option_parser_t opp) {
 	option_parser_register(opp, "-ptx_opcode_latency_int", OPT_CSTR, &opcode_latency_int,
-			"Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,19,25,145",
-			"1,1,19,25,145");
+			"Opcode latencies for integers <ADD,MAX,MUL,MAD,DIV,SHFL>"
+			"Default 1,1,19,25,145,32",
+			"1,1,19,25,145,32");
 	option_parser_register(opp, "-ptx_opcode_latency_fp", OPT_CSTR, &opcode_latency_fp,
 			"Opcode latencies for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
 			"Default 1,1,1,1,30",
@@ -91,9 +91,9 @@ void ptx_opcocde_latency_options (option_parser_t opp) {
 			"Default 64",
 			"64");
 	option_parser_register(opp, "-ptx_opcode_initiation_int", OPT_CSTR, &opcode_initiation_int,
-			"Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV>"
-			"Default 1,1,4,4,32",
-			"1,1,4,4,32");
+			"Opcode initiation intervals for integers <ADD,MAX,MUL,MAD,DIV,SHFL>"
+			"Default 1,1,4,4,32,4",
+			"1,1,4,4,32,4");
 	option_parser_register(opp, "-ptx_opcode_initiation_fp", OPT_CSTR, &opcode_initiation_fp,
 			"Opcode initiation intervals for single precision floating points <ADD,MAX,MUL,MAD,DIV>"
 			"Default 1,1,1,1,5",
@@ -648,12 +648,12 @@ void ptx_instruction::set_bar_type()
 
 void ptx_instruction::set_opcode_and_latency()
 {
-	unsigned int_latency[5];
+	unsigned int_latency[6];
 	unsigned fp_latency[5];
 	unsigned dp_latency[5];
 	unsigned sfu_latency;
 	unsigned tensor_latency;
-	unsigned int_init[5];
+	unsigned int_init[6];
 	unsigned fp_init[5];
 	unsigned dp_init[5];
 	unsigned sfu_init;
@@ -664,10 +664,11 @@ void ptx_instruction::set_opcode_and_latency()
 	 * [2] MUL
 	 * [3] MAD
 	 * [4] DIV
+	 * [5] SHFL
 	 */
-	sscanf(opcode_latency_int, "%u,%u,%u,%u,%u",
+	sscanf(opcode_latency_int, "%u,%u,%u,%u,%u,%u",
 			&int_latency[0],&int_latency[1],&int_latency[2],
-			&int_latency[3],&int_latency[4]);
+			&int_latency[3],&int_latency[4],&int_latency[5]);
 	sscanf(opcode_latency_fp, "%u,%u,%u,%u,%u",
 			&fp_latency[0],&fp_latency[1],&fp_latency[2],
 			&fp_latency[3],&fp_latency[4]);
@@ -678,9 +679,9 @@ void ptx_instruction::set_opcode_and_latency()
 			&sfu_latency);
 	sscanf(opcode_latency_tensor, "%u",
 			&tensor_latency);
-	sscanf(opcode_initiation_int, "%u,%u,%u,%u,%u",
+	sscanf(opcode_initiation_int, "%u,%u,%u,%u,%u,%u",
 			&int_init[0],&int_init[1],&int_init[2],
-			&int_init[3],&int_init[4]);
+			&int_init[3],&int_init[4],&int_init[5]);
 	sscanf(opcode_initiation_fp, "%u,%u,%u,%u,%u",
 			&fp_init[0],&fp_init[1],&fp_init[2],
 			&fp_init[3],&fp_init[4]);
@@ -873,8 +874,8 @@ void ptx_instruction::set_opcode_and_latency()
        op=TENSOR_CORE_OP;
 	   break;
    case SHFL_OP:
-	   latency = 32;
-	   initiation_interval = 4;
+	   latency = int_latency[5];
+	   initiation_interval = int_init[5];
 	   break;
    default: 
        break;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3002,7 +3002,7 @@ void shader_core_config::set_pipeline_latency() {
 
 		//calculate the max latency  based on the input
 
-		unsigned int_latency[5];
+		unsigned int_latency[6];
 		unsigned fp_latency[5];
 		unsigned dp_latency[5];
 		unsigned sfu_latency;
@@ -3014,10 +3014,11 @@ void shader_core_config::set_pipeline_latency() {
 			 * [2] MUL
 			 * [3] MAD
 			 * [4] DIV
+			 * [5] SHFL
 			 */
-			sscanf(opcode_latency_int, "%u,%u,%u,%u,%u",
+			sscanf(opcode_latency_int, "%u,%u,%u,%u,%u,%u",
 					&int_latency[0],&int_latency[1],&int_latency[2],
-					&int_latency[3],&int_latency[4]);
+					&int_latency[3],&int_latency[4],&int_latency[5]);
 			sscanf(opcode_latency_fp, "%u,%u,%u,%u,%u",
 					&fp_latency[0],&fp_latency[1],&fp_latency[2],
 					&fp_latency[3],&fp_latency[4]);
@@ -3034,7 +3035,7 @@ void shader_core_config::set_pipeline_latency() {
 		max_sfu_latency = std::max(dp_latency[4],sfu_latency);
 		//assume that the max operation has the max latency
 		max_sp_latency = fp_latency[1];
-		max_int_latency = int_latency[1];
+		max_int_latency = std::max(int_latency[1],int_latency[5]);
 		max_dp_latency = dp_latency[1];
 		max_tensor_core_latency = tensor_latency;
 


### PR DESCRIPTION
shfl latency is hardcoded to 32, but int_unit pipeline depth is set to int_latency[1](==max op latency), so sigsegv occurs. so shfl latency is added to config and option parser