### PR TITLE
Assortment of OpenCL fixes

### DIFF
--- a/libopencl/opencl_runtime_api.cc
+++ b/libopencl/opencl_runtime_api.cc
@@ -950,6 +950,17 @@ clEnqueueNDRangeKernel(cl_command_queue command_queue,
 	   gpgpu_ptx_sim_memcpy_symbol( "%_global_block_offset", zeros, 3 * sizeof(int), 0, 1, gpu );
    }
    kernel_info_t *grid = gpgpu_opencl_ptx_sim_init_grid(kernel->get_implementation(),params,GridDim,BlockDim,gpu);
+
+   //do dynamic PDOM analysis for performance simulation scenario
+   std::string kname = grid->name();
+   function_info *kernel_func_info = grid->entry();
+   if (kernel_func_info->is_pdom_set()) {
+      printf("GPGPU-Sim PTX: PDOM analysis already done for %s \n", kname.c_str() );
+   } else {
+      printf("GPGPU-Sim PTX: finding reconvergence points for \'%s\'...\n", kname.c_str() );
+      kernel_func_info->do_pdom();
+      kernel_func_info->set_pdom();
+   }
    if ( g_ptx_sim_mode )
       gpgpu_opencl_ptx_sim_main_func( grid );
    else

--- a/libopencl/opencl_runtime_api.cc
+++ b/libopencl/opencl_runtime_api.cc
@@ -1256,6 +1256,35 @@ clGetProgramInfo(cl_program         program,
 }
 
 extern CL_API_ENTRY cl_int CL_API_CALL
+clGetProgramBuildInfo (cl_program            program,
+                       cl_device_id          device,
+                       cl_program_build_info param_name,
+                       size_t                param_value_size,
+                       void *                param_value,
+                       size_t *              param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
+{
+   char *buf = (char*)param_value;
+
+   switch( param_name ) {
+   case CL_PROGRAM_BUILD_STATUS:
+      CL_CASE( cl_build_status, CL_BUILD_SUCCESS );
+      break;
+   case CL_PROGRAM_BUILD_OPTIONS:
+   case CL_PROGRAM_BUILD_LOG:
+      CL_STRING_CASE( "" );
+      break;
+   case CL_PROGRAM_BINARY_TYPE:
+      CL_CASE( cl_program_binary_type, CL_PROGRAM_BINARY_TYPE_EXECUTABLE );
+      break;
+   default:
+      return CL_INVALID_VALUE;
+      break;
+   }
+
+   return CL_SUCCESS;
+}
+
+extern CL_API_ENTRY cl_int CL_API_CALL
 clEnqueueCopyBuffer(cl_command_queue    command_queue, 
                     cl_mem              src_buffer,
                     cl_mem              dst_buffer, 


### PR DESCRIPTION
This pull request contain some of the clean fixes I performed to make OpenCL simulation work again in the current dev branch.

In addition to this, I worked around Issue #138 by simply defining no_of_ptx in opencl_runtime_api.cc . I didn't include this change in the pull request as I am unable to oversee the consequences of such a change.
Other changes not included but crucial for running OpenCL benchmarks again appear to be non-portable:

-  ptx_loader.cc contains some sed commands to change the version number in the PTX intermediate. Both the search and the replace version number had to be changed to work with the toolchain on my PC.
- Changed the default sm_version in gpgpu_ptxinfo_load_from_string() from 20 to 35, to match the GPU in my PC.

Similar non-portable changes might be required for anyone who wishes to test these patches in greater detail.