### PR TITLE
Bug fix: over counting completed instruction for vector load

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -1696,6 +1696,7 @@ void ldst_unit::L1_latency_queue_cycle()
 			   assert( !read_sent );
 			   l1_latency_queue[0] = NULL;
 			   if ( mf_next->get_inst().is_load() ) {
+				   bool insn_completed = false;
 				   for ( unsigned r=0; r < MAX_OUTPUT_VALUES; r++)
 					   if (mf_next->get_inst().out[r] > 0)
 					   {
@@ -1705,9 +1706,12 @@ void ldst_unit::L1_latency_queue_cycle()
 						   {
 							m_pending_writes[mf_next->get_inst().warp_id()].erase(mf_next->get_inst().out[r]);
 							m_scoreboard->releaseRegister(mf_next->get_inst().warp_id(),mf_next->get_inst().out[r]);
-							m_core->warp_inst_complete(mf_next->get_inst());
+							insn_completed = true;
 						   }
 					   }
+
+				   if (insn_completed)
+					   m_core->warp_inst_complete(mf_next->get_inst());
 			   }
 
 			   //For write hit in WB policy


### PR DESCRIPTION
In case of a "vector load" instruction which has multiple register destinations (e.g. `ld.global.v4.u32 {%r1903, %r1902, %r1905, %r1904}, [%rd384]`), ldst_unit::L1_latency_queue_cycle() would call warp_inst_complete() multiple times and hence over-count the number of completed instructions. This behavior is inconsistent with other ldst_unit functions such as ldst_unit::writeback().

Fix: move the warp_inst_complete() call out of the for loop iterating output registers. 