### PR TITLE
Enabled CUDA 10. Added implementations for __cudaPushCallConfiguratio…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,7 @@ Version 4.0.0 (development branch) versus 3.2.3
 3- Addig new system stats: gpu occupancy, L2BW, etc
 -Library:
 1  Enabled CUTLASS Library on GPGPU-Sim
+2  Enabled CUDA 10
 -Regression:
 1- Added TensorCore Regression Kernel
 -Configs:

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ $(SIM_LIB_DIR)/libcudart.so: makedirs $(LIBS) cudalib
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.9.0 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.9.0; fi
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.9.1 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.9.1; fi
 	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.9.2 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.9.2; fi
+	if [ ! -f $(SIM_LIB_DIR)/libcudart.so.10.0 ]; then ln -s libcudart.so $(SIM_LIB_DIR)/libcudart.so.10.0; fi
 
 $(SIM_LIB_DIR)/libcudart.dylib: makedirs $(LIBS) cudalib
 	g++ -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,1.1,-current_version,1.1\

--- a/libcuda/cuda_api.h
+++ b/libcuda/cuda_api.h
@@ -234,11 +234,11 @@ typedef struct CUgraphicsResource_st *CUgraphicsResource; /**< CUDA graphics int
 typedef unsigned long long CUtexObject;                   /**< An opaque value that represents a CUDA texture object */
 typedef unsigned long long CUsurfObject;                  /**< An opaque value that represents a CUDA surface object */
 
-#if CUDA_VERSION < 1000
+#if CUDART_VERSION < 10000
 typedef struct CUuuid_st {                                /**< CUDA definition of UUID */
     char bytes[16];
 } CUuuid;
-#endif
+#endif // #if CUDART_VERSION < 10000
 
 #if __CUDA_API_VERSION >= 4010
 

--- a/libcuda/cuda_api.h
+++ b/libcuda/cuda_api.h
@@ -234,10 +234,11 @@ typedef struct CUgraphicsResource_st *CUgraphicsResource; /**< CUDA graphics int
 typedef unsigned long long CUtexObject;                   /**< An opaque value that represents a CUDA texture object */
 typedef unsigned long long CUsurfObject;                  /**< An opaque value that represents a CUDA surface object */
 
+#if CUDA_VERSION < 1000
 typedef struct CUuuid_st {                                /**< CUDA definition of UUID */
     char bytes[16];
 } CUuuid;
-
+#endif
 
 #if __CUDA_API_VERSION >= 4010
 

--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1449,7 +1449,7 @@ __host__ cudaError_t CUDARTAPI cudaConfigureCall(dim3 gridDim, dim3 blockDim, si
 }
 
 
-#if CUDA_VERSION >= 1000
+#if CUDART_VERSION >= 10000
 /*
 * CUDA 10 requires a new CUDA kernel launch sequence
 * A call to __cudaPushCallConfiguration() preceeds any call to cudaLaunchKernel()
@@ -1489,7 +1489,7 @@ __host__ cudaError_t CUDARTAPI __cudaPopCallConfiguration()
   return cudaSuccess;
 }
 
-#endif // #if CUDA_VERSION >= 1000
+#endif // #if CUDART_VERSION >= 10000
 
 
 __host__ cudaError_t CUDARTAPI cudaSetupArgument(const void *arg, size_t size, size_t offset)
@@ -1596,12 +1596,12 @@ __host__ cudaError_t CUDARTAPI cudaLaunchKernel ( const char* hostFun, dim3 grid
         CUctx_st *context = GPGPUSim_Context();
         function_info *entry = context->get_kernel(hostFun);
 
-#if CUDA_VERSION >= 1000
+#if CUDART_VERSION >= 10000
   assert(g_cudaPushArgsBuffer::g_is_initialized == false);
   cudaConfigureCall(g_cudaPushArgsBuffer::g_gridDim, g_cudaPushArgsBuffer::g_blockDim, g_cudaPushArgsBuffer::g_sharedMem, g_cudaPushArgsBuffer::g_stream);
 #else
-    cudaConfigureCall(gridDim, blockDim, sharedMem, stream);
-#endif // #if CUDA_VERSION >= 1000
+  cudaConfigureCall(gridDim, blockDim, sharedMem, stream);
+#endif // #if CUDART_VERSION >= 10000
   
     	for(unsigned i = 0; i < entry->num_args(); i++){
         	std::pair<size_t, unsigned> p = entry->get_param_config(i);

--- a/linux-so-version.txt
+++ b/linux-so-version.txt
@@ -6,3 +6,5 @@ libcudart.so.9.2{
 };
 libcuda.so.1{
 };
+libcudart.so.10.0{
+};

--- a/setup_environment
+++ b/setup_environment
@@ -51,9 +51,10 @@ CC_VERSION=`gcc --version | head -1 | awk '{for(i=1;i<=NF;i++){ if(match($i,/^[0
 
 CUDA_VERSION_STRING=`$CUDA_INSTALL_PATH/bin/nvcc --version | awk '/release/ {print $5;}' | sed 's/,//'`;
 export CUDA_VERSION_NUMBER=`echo $CUDA_VERSION_STRING | sed 's/\./ /' | awk '{printf("%02u%02u", 10*int($1), 10*$2);}'`
-if [ $CUDA_VERSION_NUMBER -gt 9100 -o $CUDA_VERSION_NUMBER -lt 2030  ]; then
+if [ $CUDA_VERSION_NUMBER -gt 10000 -o $CUDA_VERSION_NUMBER -lt 2030  ]; then
 	echo "ERROR ** GPGPU-Sim version $GPGPUSIM_VERSION_STRING not tested with CUDA version $CUDA_VERSION_STRING (please see README)";
-	return
+	echo $CUDA_VERSION_NUMBER
+  return
 fi
 
 if [ $CUDA_VERSION_NUMBER -ge 6000 ]; then


### PR DESCRIPTION
Enabled CUDA 10. 
Added implementations for __cudaPushCallConfiguration and __cudaPopCallConfiguration, neither of which are documented in the CUDA API but they proceed any cudaLaunchKernel() call and push the call configuration on a stack which is then popped when cudaLaunchKernel() is called. Currently, the max stack size is 1, an assert will be triggered when this is violated.