### PR TITLE
Fix cudaDeviceGetAttribute(81) and cudart version for cudaPopConfiguration

### DIFF
--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1449,7 +1449,7 @@ __host__ cudaError_t CUDARTAPI cudaConfigureCall(dim3 gridDim, dim3 blockDim, si
 }
 
 
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 9020
 /*
 * CUDA 10 requires a new CUDA kernel launch sequence
 * A call to __cudaPushCallConfiguration() preceeds any call to cudaLaunchKernel()
@@ -1596,7 +1596,7 @@ __host__ cudaError_t CUDARTAPI cudaLaunchKernel ( const char* hostFun, dim3 grid
         CUctx_st *context = GPGPUSim_Context();
         function_info *entry = context->get_kernel(hostFun);
 
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 9020
   assert(g_cudaPushArgsBuffer::g_is_initialized == false);
   cudaConfigureCall(g_cudaPushArgsBuffer::g_gridDim, g_cudaPushArgsBuffer::g_blockDim, g_cudaPushArgsBuffer::g_sharedMem, g_cudaPushArgsBuffer::g_stream);
 #else

--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -320,9 +320,6 @@ void shader_core_config::reg_options(class OptionParser * opp)
     option_parser_register(opp, "-adaptive_volta_cache_config", OPT_BOOL, &adaptive_volta_cache_config,
                  "adaptive_volta_cache_config",
                  "0");
-    option_parser_register(opp, "-gpgpu_shmem_size", OPT_UINT32, &gpgpu_shmem_sizeDefault,
-                 "Size of shared memory per shader core (default 16kB)",
-                 "16384");
     option_parser_register(opp, "-gpgpu_shmem_size_PrefL1", OPT_UINT32, &gpgpu_shmem_sizePrefL1,
                  "Size of shared memory per shader core (default 16kB)",
                  "16384");
@@ -778,7 +775,7 @@ gpgpu_sim::gpgpu_sim( const gpgpu_sim_config &config )
 
 int gpgpu_sim::shared_mem_size() const
 {
-   return m_shader_config->gpgpu_shmem_size;
+   return m_shader_config->gpgpu_shmem_size * m_shader_config->n_simt_cores_per_cluster;
 }
 
 int gpgpu_sim::shared_mem_per_block() const

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -1399,7 +1399,7 @@ struct shader_core_config : public core_config
 	}
 
 	delete[] tokd;
-	
+	gpgpu_shmem_sizeDefault = gpgpu_shmem_size;
         if (n_thread_per_shader > MAX_THREAD_PER_SM) {
            printf("GPGPU-Sim uArch: Error ** increase MAX_THREAD_PER_SM in abstract_hardware_model.h from %u to %u\n", 
                   MAX_THREAD_PER_SM, n_thread_per_shader);


### PR DESCRIPTION
1. cudaPushCallConfiguration is used in CUDA 9.2 so i changed preprocessor.
2. I found that cudaDeviceGetAttribute(cudaDevAttrMaxSharedMemoryPerMultiprocessor) should return the maximum amount of shared memory per "Multiprecessor"(which is same as a 'cluster' in gpgpu-sim ) but it currently return the maximum amount of shared memory per 'core'. so i add multiplication at shared_mem_size()
3. i found that gpgpu_shmem_size option is duplicated and only the first option parser works, so i removed second one and assign gpgpu_shmem_sizeDefault at its init() function.

