### PR TITLE
Change addresses to use 64 bits. Fixes errors with generic addressing.

### DIFF
--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -75,8 +75,8 @@ enum AdaptiveCache { FIXED = 0, ADAPTIVE_VOLTA = 1 };
 
 typedef unsigned long long new_addr_type;
 typedef unsigned long long cudaTextureObject_t;
-typedef unsigned address_type;
-typedef unsigned addr_t;
+typedef unsigned long long address_type;
+typedef unsigned long long addr_t;
 
 // the following are operations the timing model can see
 #define SPECIALIZED_UNIT_NUM 8


### PR DESCRIPTION
Fixes errors due to address overflow.
Below is an example of correct code that would throw an error in GPGPU-Sim:

`
#include <iostream>
using namespace std;
#define VALUE 256ULL * 1024ULL * 1024ULL
__global__ void test(int *data1, int *data2)
{
    int value;
    asm volatile("ld.s32 %0, [%1];": "=r"(value) : "l"(data1));
    asm volatile("st.s32 [%0], %1;":: "l"(data2), "r"(value));
}

int main()
{
    int *data1, *data2;
    cudaMalloc((void**)&data1, VALUE * sizeof(int));
    cudaMalloc((void**)&data2, VALUE * sizeof(int));
    int dummy = 100;
    cudaMemcpy(&data1[VALUE - 1], &dummy, sizeof(int), cudaMemcpyHostToDevice);
    test<<<1, 1>>>(&data1[VALUE - 1], data2);
    int data;
    cudaMemcpy(&data, data2, sizeof(int), cudaMemcpyDeviceToHost);
    cout << data << "\n";
}
`

The address for global memory starts at 0xc000000. By allocating VALUE * sizeof(int) size and using the last index, this address overflows a 32 bit location, causing the simulator to incorrectly read the address.