### PR TITLE
fixed exception for parallel intensity plots in AerialVision

### DIFF
--- a/aerialvision/guiclasses.py
+++ b/aerialvision/guiclasses.py
@@ -1365,7 +1365,8 @@ class graphManager:
         interpolation = 'nearest'
         norm = plotFormat.norm
         im = self.plot.imshow(y, cmap = cmap, interpolation = interpolation, aspect = 'auto', norm = norm )
-        tmp = im.get_axes().get_position().get_points()
+        # tmp = im.get_axes().get_position().get_points()
+        tmp = im.get_window_extent().get_points()
 
         if (plotID in self.cbarAxes):
             self.figure.delaxes(self.cbarAxes[plotID])


### PR DESCRIPTION
Exception `AttributeError: 'AxesImage' object has no attribute 'get_axes'` occurs when creating/refreshing a parallel intensity plot. Updated the get_axes().get_position() matplotlib call to get_window_extent(). 