### PR TITLE
Update gpgpusim.config for GTX480, to make GDDR5 DDR instead QDR

### DIFF
--- a/configs/tested-cfgs/SM2_GTX480/gpgpusim.config
+++ b/configs/tested-cfgs/SM2_GTX480/gpgpusim.config
@@ -121,7 +121,7 @@
 -gpgpu_n_mem_per_ctrlr 2
 -gpgpu_dram_buswidth 4
 -gpgpu_dram_burst_length 8
--dram_data_command_freq_ratio 4  # GDDR5 is QDR
+-dram_data_command_freq_ratio 2  # GDDR5 is DDR
 -gpgpu_mem_address_mask 1
 -gpgpu_mem_addr_mapping dramid@8;00000000.00000000.00000000.00000000.0000RRRR.RRRRRRRR.BBBCCCCB.CCSSSSSS
 


### PR DESCRIPTION
According to JEDEC document JESD212C "GRAPHICS DOUBLE DATA RATE (GDDR5) SGRAM STANDARD", GDDR5 is DDR (page 8, section 2.1, "Features")