### PR TITLE
debug smem_latency at config KEPLER TITAN

### DIFF
--- a/configs/tested-cfgs/SM3_KEPLER_TITAN/gpgpusim.config
+++ b/configs/tested-cfgs/SM3_KEPLER_TITAN/gpgpusim.config
@@ -116,7 +116,7 @@
 -icnt_flit_size 40
 -gpgpu_n_cluster_ejection_buffer_size 32
 -gpgpu_l1_latency 82
--smem_latency 24
+-gpgpu_smem_latency 24
 -gpgpu_flush_l1_cache 1
 
 # 32 sets, each 128 bytes 16-way for each memory sub partition (128 KB per memory sub partition). This gives 1.5MB L2 cache


### PR DESCRIPTION
config for smem_latency is -gpgpu_smem_latency but at config KEPLER TITAN is -smem_latency 