### PR TITLE
Fix: parsing `barrier{.cta}.*` in PTX.

### DIFF
--- a/src/cuda-sim/ptx.l
+++ b/src/cuda-sim/ptx.l
@@ -69,6 +69,7 @@ andn	TC; yylval->int_value = ANDN_OP; return OPCODE;
 atom	TC; yylval->int_value = ATOM_OP; return OPCODE;
 bar.warp 	TC; yylval->int_value = NOP_OP; return OPCODE;
 bar 	TC; yylval->int_value = BAR_OP; return OPCODE;
+barrier 	TC; yylval->int_value = BAR_OP; return OPCODE;
 bfe     TC; yylval->int_value = BFE_OP; return OPCODE;
 bfi     TC; yylval->int_value = BFI_OP; return OPCODE;
 bfind   TC; yylval->int_value = BFIND_OP; return OPCODE;


### PR DESCRIPTION
Added lexer rule:
`barrier 	TC; yylval->int_value = BAR_OP; return OPCODE;`

Instructions like `barrier.sync` could cause syntax errors like this:

![20240421-185611](https://github.com/gpgpu-sim/gpgpu-sim_distribution/assets/29171574/1bd92ae3-b0c7-42b6-a2ab-c27787693219)

See: [Parallel Synchronization and Communication Instructions: bar, barrier](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-bar)
