### PR TITLE
Support for CUDA 12.x and Ubuntu 24

### DIFF
--- a/libcuda/cuda_runtime_api.cc
+++ b/libcuda/cuda_runtime_api.cc
@@ -1942,6 +1942,7 @@ __host__ cudaError_t CUDARTAPI cudaBindTextureInternal(
     size_t *offset, const struct textureReference *texref, const void *devPtr,
     const struct cudaChannelFormatDesc *desc, size_t size __dv(UINT_MAX),
     gpgpu_context *gpgpu_ctx = NULL) {
+#if (CUDART_VERSION <= 1200)
   gpgpu_context *ctx;
   if (gpgpu_ctx) {
     ctx = gpgpu_ctx;
@@ -1978,12 +1979,14 @@ __host__ cudaError_t CUDARTAPI cudaBindTextureInternal(
   gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
   devPtr = (void *)(long long)array->devPtr32;
   printf("GPGPU-Sim PTX: devPtr = %p\n", devPtr);
+#endif
   return g_last_cudaError = cudaSuccess;
 }
 
 __host__ cudaError_t CUDARTAPI cudaBindTextureToArrayInternal(
     const struct textureReference *texref, const struct cudaArray *array,
     const struct cudaChannelFormatDesc *desc, gpgpu_context *gpgpu_ctx = NULL) {
+#if (CUDART_VERSION <= 1200)
   gpgpu_context *ctx;
   if (gpgpu_ctx) {
     ctx = gpgpu_ctx;
@@ -2001,11 +2004,13 @@ __host__ cudaError_t CUDARTAPI cudaBindTextureToArrayInternal(
          gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
   printf("GPGPU-Sim PTX:   Texture Normalized? = %d\n", texref->normalized);
   gpu->gpgpu_ptx_sim_bindTextureToArray(texref, array);
+#endif
   return g_last_cudaError = cudaSuccess;
 }
 
 __host__ cudaError_t CUDARTAPI cudaUnbindTextureInternal(
     const struct textureReference *texref, gpgpu_context *gpgpu_ctx = NULL) {
+#if (CUDART_VERSION <= 1200)
   gpgpu_context *ctx;
   if (gpgpu_ctx) {
     ctx = gpgpu_ctx;
@@ -2025,6 +2030,7 @@ __host__ cudaError_t CUDARTAPI cudaUnbindTextureInternal(
          gpu->gpgpu_ptx_sim_findNamefromTexture(texref));
 
   gpu->gpgpu_ptx_sim_unbindTexture(texref);
+#endif
   return g_last_cudaError = cudaSuccess;
 }
 

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -125,6 +125,7 @@ cudaLaunchDeviceV2_init_perWarp, cudaLaunchDevicV2_perKernel>"
 void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(
     const char *name, const struct textureReference *texref, int dim,
     int readmode, int ext) {
+#if (CUDART_VERSION <= 1200)
   std::string texname(name);
   if (m_NameToTextureRef.find(texname) == m_NameToTextureRef.end()) {
     m_NameToTextureRef[texname] = std::set<const struct textureReference *>();
@@ -148,6 +149,7 @@ void gpgpu_t::gpgpu_ptx_sim_bindNameToTexture(
   const textureReferenceAttr *texAttr = new textureReferenceAttr(
       texref, dim, (enum cudaTextureReadMode)readmode, ext);
   m_NameToAttribute[texname] = texAttr;
+#endif
 }
 
 const char *gpgpu_t::gpgpu_ptx_sim_findNamefromTexture(
@@ -185,6 +187,7 @@ unsigned int intLOGB2(unsigned int v) {
 
 void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(
     const struct textureReference *texref, const struct cudaArray *array) {
+#if (CUDART_VERSION <= 1200)
   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
 
   std::map<std::string, const struct cudaArray *>::const_iterator t =
@@ -258,14 +261,17 @@ void gpgpu_t::gpgpu_ptx_sim_bindTextureToArray(
   texInfo->texel_size = texel_size;
   texInfo->texel_size_numbits = intLOGB2(texel_size);
   m_NameToTextureInfo[texname] = texInfo;
+#endif
 }
 
 void gpgpu_t::gpgpu_ptx_sim_unbindTexture(
     const struct textureReference *texref) {
+#if (CUDART_VERSION <= 1200)
   // assumes bind-use-unbind-bind-use-unbind pattern
   std::string texname = gpgpu_ptx_sim_findNamefromTexture(texref);
   m_NameToCudaArray.erase(texname);
   m_NameToTextureInfo.erase(texname);
+#endif
 }
 
 #define MAX_INST_SIZE 8 /*bytes*/

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -6046,6 +6046,7 @@ void textureNormalizeOutput(const struct cudaChannelFormatDesc &desc,
 }
 
 void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
+#if (CUDART_VERSION <= 1200)
   unsigned dimension = pI->dimension();
   const operand_info &dst =
       pI->dst();  // the registers to which fetched texel will be placed
@@ -6373,6 +6374,7 @@ void tex_impl(const ptx_instruction *pI, ptx_thread_info *thread) {
   }
 
   thread->set_vector_operand_values(dst, data1, data2, data3, data4);
+#endif
 }
 
 void txq_impl(const ptx_instruction *pI, ptx_thread_info *thread) {

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <iostream>
 #include <list>
+#include <stdint.h>
 #include "../abstract_hardware_model.h"
 #include "../option_parser.h"
 #include "../trace.h"


### PR DESCRIPTION
No more textures in CUDA 12.
Some minor include issues with the new gcc version.