### PR TITLE
fix(shader): correct pI1→pI2 variable in dual-issue decode stats

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -908,8 +908,8 @@ void shader_core_ctx::decode() {
         m_warp[m_inst_fetch_buffer.m_warp_id]->ibuffer_fill(1, pI2);
         m_warp[m_inst_fetch_buffer.m_warp_id]->inc_inst_in_pipeline();
         m_stats->m_num_decoded_insn[m_sid]++;
-        if ((pI1->oprnd_type == INT_OP) ||
-            (pI1->oprnd_type == UN_OP)) {  // these counters get added up in
+        if ((pI2->oprnd_type == INT_OP) ||
+            (pI2->oprnd_type == UN_OP)) {  // these counters get added up in
                                            // mcPat to compute scheduler power
           m_stats->m_num_INTdecoded_insn[m_sid]++;
         } else if (pI2->oprnd_type == FP_OP) {


### PR DESCRIPTION
## Summary

Fix an incorrect variable reference in `shader_core_ctx::decode()` that causes wrong instruction type statistics to be recorded for the second instruction in dual-issue scenarios.

## Problem

In `shader.cc` lines 911–912, the operand type check for the second decoded instruction (`pI2`) incorrectly references `pI1`:

```cpp
// Before (buggy)
if ((pI1->oprnd_type == INT_OP) ||
    (pI1->oprnd_type == UN_OP)) {   // ← should be pI2
    m_stats->m_num_INTdecoded_insn[m_sid]++;
} else if (pI2->oprnd_type == FP_OP) {
    m_stats->m_num_FPdecoded_insn[m_sid]++;
}
```

This causes `m_num_INTdecoded_insn` to be incremented based on `pI1`'s operand type when classifying `pI2`, silently producing incorrect decode statistics for dual-issued instructions. The bug is latent — it only manifests when both instructions are decoded in the same cycle and their operand types differ.

## Fix

```cpp
// After
if ((pI2->oprnd_type == INT_OP) ||
    (pI2->oprnd_type == UN_OP)) {
    m_stats->m_num_INTdecoded_insn[m_sid]++;
} else if (pI2->oprnd_type == FP_OP) {
    m_stats->m_num_FPdecoded_insn[m_sid]++;
}
```

## Impact

- **No behavioral change** to simulation execution — only statistics counters are affected
- Simulation output (IPC, memory access patterns, functional correctness) is unchanged
- Decode statistics (`m_num_INTdecoded_insn`, `m_num_FPdecoded_insn`) will now correctly reflect the second instruction's operand type in dual-issue scenarios
- These counters feed into McPAT/AccelWattch for scheduler power estimation

## Testing

Verified with Rodinia 2.0 `hotspot` benchmark on GTX1080Ti config. Simulation output log is identical; only per-SM decode stat counters change for workloads with dual-issued mixed INT/FP instruction pairs.

```bash
source setup_environment release
make -j
# Run any CUDA workload with dual-issue enabled and inspect
# gpgpu_stats output for m_num_INTdecoded_insn / m_num_FPdecoded_insn
```

