### PR TITLE
fix(shader): replace raw new[] with std::vector in arbiter_t

### DIFF
--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -823,28 +823,18 @@ class opndcoll_rfu_t {  // operand collector based register file unit
   class arbiter_t {
    public:
     // constructors
-    arbiter_t() {
-      m_queue = NULL;
-      m_allocated_bank = NULL;
-      m_allocator_rr_head = NULL;
-      _inmatch = NULL;
-      _outmatch = NULL;
-      _request = NULL;
-      m_last_cu = 0;
-    }
+    arbiter_t() : m_num_banks(0), m_num_collectors(0), m_last_cu(0) {}
     void init(unsigned num_cu, unsigned num_banks) {
       assert(num_cu > 0);
       assert(num_banks > 0);
       m_num_collectors = num_cu;
       m_num_banks = num_banks;
-      _inmatch = new int[m_num_banks];
-      _outmatch = new int[m_num_collectors];
-      _request = new int *[m_num_banks];
-      for (unsigned i = 0; i < m_num_banks; i++)
-        _request[i] = new int[m_num_collectors];
-      m_queue = new std::list<op_t>[num_banks];
-      m_allocated_bank = new allocation_t[num_banks];
-      m_allocator_rr_head = new unsigned[num_cu];
+      _inmatch.resize(m_num_banks);
+      _outmatch.resize(m_num_collectors);
+      _request.resize(m_num_banks, std::vector<int>(m_num_collectors, 0));
+      m_queue.resize(num_banks);
+      m_allocated_bank.resize(num_banks);
+      m_allocator_rr_head.resize(num_cu);
       for (unsigned n = 0; n < num_cu; n++)
         m_allocator_rr_head[n] = n % num_banks;
       reset_alloction();
@@ -903,16 +893,16 @@ class opndcoll_rfu_t {  // operand collector based register file unit
     unsigned m_num_banks;
     unsigned m_num_collectors;
 
-    allocation_t *m_allocated_bank;  // bank # -> register that wins
-    std::list<op_t> *m_queue;
+    std::vector<allocation_t> m_allocated_bank;  // bank # -> register that wins
+    std::vector<std::list<op_t>> m_queue;
 
-    unsigned *
+    std::vector<unsigned>
         m_allocator_rr_head;  // cu # -> next bank to check for request (rr-arb)
     unsigned m_last_cu;       // first cu to check while arb-ing banks (rr)
 
-    int *_inmatch;
-    int *_outmatch;
-    int **_request;
+    std::vector<int> _inmatch;
+    std::vector<int> _outmatch;
+    std::vector<std::vector<int>> _request;
   };
 
   class input_port_t {


### PR DESCRIPTION
## Summary

- Replace all 6 raw `new[]` allocations in `arbiter_t` with `std::vector`, fixing a memory leak caused by missing destructor
- One `arbiter_t` exists per operand collector unit per SM, so the leak scales with GPU config size

## Problem

`arbiter_t::init()` allocated arrays with `new`/`new[]` but the class had no destructor:

```cpp
_inmatch = new int[m_num_banks];
_outmatch = new int[m_num_collectors];
_request = new int *[m_num_banks];       // + inner new int[] per bank
m_queue = new std::list<op_t>[num_banks];
m_allocated_bank = new allocation_t[num_banks];
m_allocator_rr_head = new unsigned[num_cu];
```

All 6 allocations leaked for the entire simulation lifetime.

## Fix

Replace raw pointer members with `std::vector`:

```cpp
std::vector<int> _inmatch;
std::vector<int> _outmatch;
std::vector<std::vector<int>> _request;
std::vector<std::list<op_t>> m_queue;
std::vector<allocation_t> m_allocated_bank;
std::vector<unsigned> m_allocator_rr_head;
```

`init()` uses `resize()` instead of `new[]`. RAII handles cleanup — no manual destructor needed.

## Impact

- **No functional change** — all `operator[]` access patterns remain identical
- Eliminates per-SM memory leak that scales with config size
- Simplifies constructor (no NULL init boilerplate)

## Test plan

- [ ] Build with `source setup_environment release && make -j`
- [ ] Run Rodinia 2.0 hotspot on GTX1080Ti config — verify identical simulation output
- [ ] Valgrind/ASan run to confirm leak is resolved