### PR TITLE
refactor(shader): consolidate 20 inc*_stat methods into inc_fu_stat

### DIFF
--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -3258,6 +3258,22 @@ void warp_inst_t::print(FILE *fout) const {
   m_config->gpgpu_ctx->func_sim->ptx_print_insn(pc, fout);
   fprintf(fout, "\n");
 }
+void shader_core_ctx::inc_fu_stat(double *counter, unsigned active_count,
+                                   double latency, lane_model model,
+                                   bool update_exu) {
+  double access = (double)active_count * latency;
+  if (model != lane_model::NONE && !m_config->gpgpu_clock_gated_lanes) {
+    access += (model == lane_model::SFU)
+                  ? inactive_lanes_accesses_sfu(active_count, latency)
+                  : inactive_lanes_accesses_nonsfu(active_count, latency);
+  }
+  counter[m_sid] += access;
+  if (update_exu) {
+    m_stats->m_active_exu_threads[m_sid] += active_count;
+    m_stats->m_active_exu_warps[m_sid]++;
+  }
+}
+
 void shader_core_ctx::incexecstat(warp_inst_t *&inst) {
   // Latency numbers for next operations are used to scale the power values
   // for special operations, according observations from microbenchmarking

--- a/src/gpgpu-sim/shader.h
+++ b/src/gpgpu-sim/shader.h
@@ -2056,6 +2056,8 @@ class shader_core_mem_fetch_allocator : public mem_fetch_allocator {
   const memory_config *m_memory_config;
 };
 
+enum class lane_model { SFU, NON_SFU, NONE };
+
 class shader_core_ctx : public core_t {
  public:
   // creator:
@@ -2145,246 +2147,42 @@ class shader_core_ctx : public core_t {
 
   void incload_stat() { m_stats->m_num_loadqueued_insn[m_sid]++; }
   void incstore_stat() { m_stats->m_num_storequeued_insn[m_sid]++; }
-  void incialu_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_ialu_acesses[m_sid] =
-          m_stats->m_num_ialu_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_ialu_acesses[m_sid] =
-          m_stats->m_num_ialu_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incimul_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul_acesses[m_sid] =
-          m_stats->m_num_imul_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul_acesses[m_sid] =
-          m_stats->m_num_imul_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incimul24_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul24_acesses[m_sid] =
-          m_stats->m_num_imul24_acesses[m_sid] +
-          (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul24_acesses[m_sid] =
-          m_stats->m_num_imul24_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incimul32_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_imul32_acesses[m_sid] =
-          m_stats->m_num_imul32_acesses[m_sid] +
-          (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_imul32_acesses[m_sid] =
-          m_stats->m_num_imul32_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incidiv_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_idiv_acesses[m_sid] =
-          m_stats->m_num_idiv_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_idiv_acesses[m_sid] =
-          m_stats->m_num_idiv_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incfpalu_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fp_acesses[m_sid] =
-          m_stats->m_num_fp_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_fp_acesses[m_sid] =
-          m_stats->m_num_fp_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incfpmul_stat(unsigned active_count, double latency) {
-    // printf("FP MUL stat increament\n");
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fpmul_acesses[m_sid] =
-          m_stats->m_num_fpmul_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_fpmul_acesses[m_sid] =
-          m_stats->m_num_fpmul_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incfpdiv_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_fpdiv_acesses[m_sid] =
-          m_stats->m_num_fpdiv_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_fpdiv_acesses[m_sid] =
-          m_stats->m_num_fpdiv_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incdpalu_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_dp_acesses[m_sid] =
-          m_stats->m_num_dp_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_dp_acesses[m_sid] =
-          m_stats->m_num_dp_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incdpmul_stat(unsigned active_count, double latency) {
-    // printf("FP MUL stat increament\n");
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_dpmul_acesses[m_sid] =
-          m_stats->m_num_dpmul_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_dpmul_acesses[m_sid] =
-          m_stats->m_num_dpmul_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-  void incdpdiv_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_dpdiv_acesses[m_sid] =
-          m_stats->m_num_dpdiv_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_dpdiv_acesses[m_sid] =
-          m_stats->m_num_dpdiv_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
 
-  void incsqrt_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_sqrt_acesses[m_sid] =
-          m_stats->m_num_sqrt_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_sqrt_acesses[m_sid] =
-          m_stats->m_num_sqrt_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
+  void inc_fu_stat(double *counter, unsigned active_count, double latency,
+                   lane_model model, bool update_exu);
 
-  void inclog_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_log_acesses[m_sid] =
-          m_stats->m_num_log_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_log_acesses[m_sid] =
-          m_stats->m_num_log_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
+  // Pattern A — NON_SFU, update_exu=true
+  void incialu_stat(unsigned n, double l)   { inc_fu_stat(m_stats->m_num_ialu_acesses,   n, l, lane_model::NON_SFU, true); }
+  void incimul_stat(unsigned n, double l)   { inc_fu_stat(m_stats->m_num_imul_acesses,   n, l, lane_model::NON_SFU, true); }
+  void incimul24_stat(unsigned n, double l) { inc_fu_stat(m_stats->m_num_imul24_acesses, n, l, lane_model::NON_SFU, true); }
+  void incfpalu_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_fp_acesses,     n, l, lane_model::NON_SFU, true); }
+  void incfpmul_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_fpmul_acesses,  n, l, lane_model::NON_SFU, true); }
+  void incdpalu_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_dp_acesses,     n, l, lane_model::NON_SFU, true); }
+  void incdpmul_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_dpmul_acesses,  n, l, lane_model::NON_SFU, true); }
 
-  void incexp_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_exp_acesses[m_sid] =
-          m_stats->m_num_exp_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_exp_acesses[m_sid] =
-          m_stats->m_num_exp_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-
-  void incsin_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_sin_acesses[m_sid] =
-          m_stats->m_num_sin_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_sin_acesses[m_sid] =
-          m_stats->m_num_sin_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-
-  void inctensor_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_tensor_core_acesses[m_sid] =
-          m_stats->m_num_tensor_core_acesses[m_sid] +
-          (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_tensor_core_acesses[m_sid] =
-          m_stats->m_num_tensor_core_acesses[m_sid] +
-          (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
-
-  void inctex_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_tex_acesses[m_sid] =
-          m_stats->m_num_tex_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_sfu(active_count, latency);
-    } else {
-      m_stats->m_num_tex_acesses[m_sid] =
-          m_stats->m_num_tex_acesses[m_sid] + (double)active_count * latency;
-    }
-    m_stats->m_active_exu_threads[m_sid] += active_count;
-    m_stats->m_active_exu_warps[m_sid]++;
-  }
+  // Pattern B — SFU, update_exu=true
+  void incimul32_stat(unsigned n, double l) { inc_fu_stat(m_stats->m_num_imul32_acesses,      n, l, lane_model::SFU, true); }
+  void incidiv_stat(unsigned n, double l)   { inc_fu_stat(m_stats->m_num_idiv_acesses,        n, l, lane_model::SFU, true); }
+  void incfpdiv_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_fpdiv_acesses,       n, l, lane_model::SFU, true); }
+  void incdpdiv_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_dpdiv_acesses,       n, l, lane_model::SFU, true); }
+  void incsqrt_stat(unsigned n, double l)   { inc_fu_stat(m_stats->m_num_sqrt_acesses,        n, l, lane_model::SFU, true); }
+  void inclog_stat(unsigned n, double l)    { inc_fu_stat(m_stats->m_num_log_acesses,         n, l, lane_model::SFU, true); }
+  void incexp_stat(unsigned n, double l)    { inc_fu_stat(m_stats->m_num_exp_acesses,         n, l, lane_model::SFU, true); }
+  void incsin_stat(unsigned n, double l)    { inc_fu_stat(m_stats->m_num_sin_acesses,         n, l, lane_model::SFU, true); }
+  void inctensor_stat(unsigned n, double l) { inc_fu_stat(m_stats->m_num_tensor_core_acesses, n, l, lane_model::SFU, true); }
+  void inctex_stat(unsigned n, double l)    { inc_fu_stat(m_stats->m_num_tex_acesses,         n, l, lane_model::SFU, true); }
 
   void inc_const_accesses(unsigned active_count) {
     m_stats->m_num_const_acesses[m_sid] =
         m_stats->m_num_const_acesses[m_sid] + active_count;
   }
 
-  void incsfu_stat(unsigned active_count, double latency) {
-    m_stats->m_num_sfu_acesses[m_sid] =
-        m_stats->m_num_sfu_acesses[m_sid] + (double)active_count * latency;
-  }
-  void incsp_stat(unsigned active_count, double latency) {
-    m_stats->m_num_sp_acesses[m_sid] =
-        m_stats->m_num_sp_acesses[m_sid] + (double)active_count * latency;
-  }
-  void incmem_stat(unsigned active_count, double latency) {
-    if (m_config->gpgpu_clock_gated_lanes == false) {
-      m_stats->m_num_mem_acesses[m_sid] =
-          m_stats->m_num_mem_acesses[m_sid] + (double)active_count * latency +
-          inactive_lanes_accesses_nonsfu(active_count, latency);
-    } else {
-      m_stats->m_num_mem_acesses[m_sid] =
-          m_stats->m_num_mem_acesses[m_sid] + (double)active_count * latency;
-    }
-  }
+  // Pattern C — NON_SFU, update_exu=false
+  void incmem_stat(unsigned n, double l) { inc_fu_stat(m_stats->m_num_mem_acesses, n, l, lane_model::NON_SFU, false); }
+
+  // Pattern D — NONE, update_exu=false
+  void incsfu_stat(unsigned n, double l) { inc_fu_stat(m_stats->m_num_sfu_acesses, n, l, lane_model::NONE, false); }
+  void incsp_stat(unsigned n, double l)  { inc_fu_stat(m_stats->m_num_sp_acesses,  n, l, lane_model::NONE, false); }
   void incexecstat(warp_inst_t *&inst);
 
   void incregfile_reads(unsigned active_count) {


### PR DESCRIPTION
## Summary

Consolidate 20 near-identical power statistics methods in `shader_core_ctx` into a single parameterized implementation. No call sites were modified and simulation output is unchanged.

## Motivation

`shader_core_ctx` contained 20 methods (`incialu_stat`, `incfpalu_stat`, `incsqrt_stat`, etc.) that all followed the same three-step pattern:

1. Compute `active_count * latency`
2. Optionally add inactive lane overhead via `inactive_lanes_accesses_sfu()` or `inactive_lanes_accesses_nonsfu()` depending on the execution unit type, gated by `gpgpu_clock_gated_lanes`
3. Optionally update `m_active_exu_threads` and `m_active_exu_warps`

The only differences across all 20 methods were which counter to write, which lane overhead function to call, and whether to update the EXU counters — making this a clear consolidation opportunity.

## Changes

**`shader.h`**
- Added `enum class lane_model { SFU, NON_SFU, NONE }` to express the three execution unit categories
- Replaced each method body (~12 lines each) with a single-line delegation to `inc_fu_stat()`
- Existing public API is fully preserved — zero call site changes required

**`shader.cc`**
- Added 16-line implementation of `shader_core_ctx::inc_fu_stat()`

```cpp
void shader_core_ctx::inc_fu_stat(double *counter, unsigned active_count,
                                   double latency, lane_model model,
                                   bool update_exu) {
  double access = (double)active_count * latency;
  if (model != lane_model::NONE && !m_config->gpgpu_clock_gated_lanes) {
    access += (model == lane_model::SFU)
                  ? inactive_lanes_accesses_sfu(active_count, latency)
                  : inactive_lanes_accesses_nonsfu(active_count, latency);
  }
  counter[m_sid] += access;
  if (update_exu) {
    m_stats->m_active_exu_threads[m_sid] += active_count;
    m_stats->m_active_exu_warps[m_sid]++;
  }
}
```

## Pattern classification

All 20 methods were verified to fall into exactly four patterns:

| Pattern | lane_model | update_exu | Methods |
|---------|-----------|------------|---------|
| A | `NON_SFU` | `true` | `incialu`, `incimul`, `incimul24`, `incfpalu`, `incfpmul`, `incdpalu`, `incdpmul` (7) |
| B | `SFU` | `true` | `incimul32`, `incidiv`, `incfpdiv`, `incdpdiv`, `incsqrt`, `inclog`, `incexp`, `incsin`, `inctensor`, `inctex` (10) |
| C | `NON_SFU` | `false` | `incmem` (1) |
| D | `NONE` | `false` | `incsfu`, `incsp` (2) |

## Stats

- **-233 / +47 lines** (net: -186 lines)
- **0 call site changes**
- All counter types confirmed `double *` across all 20 methods

## Testing

Verified with Rodinia 2.0 `hotspot` on GTX1080Ti config. All `m_num_*_acesses` values in `gpgpusim.*.log` are identical before and after the change.

```bash
source setup_environment release && make -j
```